### PR TITLE
refactor(logging): logging is done with python logs instead of print [ISPGCASP-795]

### DIFF
--- a/cyclonedx/clients/ciam/cognito_client.py
+++ b/cyclonedx/clients/ciam/cognito_client.py
@@ -1,6 +1,8 @@
 """
 -> Module to house the HarborCognitoClient class
 """
+import logging
+from logging import config
 from os import environ
 
 import boto3
@@ -10,11 +12,15 @@ from cyclonedx.clients.ciam.jwt_data import JwtData
 from cyclonedx.clients.ciam.user_data import CognitoUserData
 from cyclonedx.constants import (
     COGNITO_TEAM_DELIMITER,
+    PYTHON_LOGGING_CONFIG,
     USER_POOL_CLIENT_ID_KEY,
     USER_POOL_ID_KEY,
 )
 from cyclonedx.exceptions.ciam_exception import HarborCiamError
 from cyclonedx.model.member import Member
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 class HarborCognitoClient:
@@ -108,7 +114,7 @@ class HarborCognitoClient:
                 },
             )
         except self.cognito_client.exceptions.NotAuthorizedException as err:
-            print(f"Caught NotAuthorizedException: {err}")
+            logger.info("Caught NotAuthorizedException: %s", err)
             raise HarborCiamError("Not Authorized") from err
 
         return resp["AuthenticationResult"]["AccessToken"]

--- a/cyclonedx/clients/ciam/user_data.py
+++ b/cyclonedx/clients/ciam/user_data.py
@@ -1,7 +1,14 @@
 """
 -> Module to house the CognitoUserData class
 """
+import logging
+from logging import config
 from typing import Callable
+
+from cyclonedx.constants import PYTHON_LOGGING_CONFIG
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 class CognitoUserData:
@@ -63,5 +70,5 @@ class CognitoUserData:
 
             return "" if teams == "," else teams
         except KeyError as ke:
-            print(f"KeyError while getting teams: {ke}")
+            logger.info("KeyError while getting teams %s", ke)
             return ""

--- a/cyclonedx/clients/ion_channel/ion_channel.py
+++ b/cyclonedx/clients/ion_channel/ion_channel.py
@@ -1,6 +1,8 @@
 """
 -> A module to house the Ion Channel Client and supporting functions
 """
+import logging
+from logging import config
 from time import sleep
 from typing import IO, Union
 
@@ -10,14 +12,16 @@ from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 from requests import Response
 
-from cyclonedx.constants import IC_API_KEY, IC_RULESET_TEAM_ID
-
-# pylint: disable = R0902
+from cyclonedx.constants import IC_API_KEY, IC_RULESET_TEAM_ID, PYTHON_LOGGING_CONFIG
 from cyclonedx.exceptions.ion_channel import IonChannelError
 
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
+
+# pylint: disable = R0902
+
+
 # pylint: disable = E1136
-
-
 def get_ic_urls() -> tuple:
 
     """
@@ -91,7 +95,7 @@ class IonChannelClient:
         -> Execute an http get request
         """
 
-        print(f"Sending To: GET:{url}")
+        logger.info("Sending To: GET:%s", url)
         response: Response = requests.get(
             url,
             headers=self.headers,
@@ -105,7 +109,7 @@ class IonChannelClient:
         -> Execute an http put request
         """
 
-        print(f"Sending To: PUT:{url}")
+        logger.info("Sending To: PUT:%s", url)
         response: Response = requests.put(
             url,
             headers=self.headers,
@@ -125,7 +129,7 @@ class IonChannelClient:
         -> Execute an http post request
         """
 
-        print(f"Sending To: POST:{url}")
+        logger.info("Sending To: POST:%s", url)
         if json:
             response: Response = requests.post(
                 url,
@@ -345,7 +349,7 @@ class IonChannelClient:
                 "results": results,
             }
         except KeyError as ke:
-            print(f"ERROR, no 'name' key: {report_json} {ke}")
+            logger.info("ERROR, no 'name' key: %s, %s", report_json, ke)
             return (
                 f"Error:analysis_id({analysis_id})",
                 f"Error:project_id({project_id})",
@@ -479,13 +483,13 @@ class IonChannelClient:
                     errored_projects.append(project_id)
                 else:
                     complete = False
-                    print(status_rsp_dict["data"]["message"])
+                    logger.info(status_rsp_dict["data"]["message"])
 
                     # Try not to hammer the Ion Channel API
                     sleep(1)
 
-            print(f"Extracting data from {len(finished_projects)} projects")
-            print(f"{len(errored_projects)} projects are failing")
+            logger.info("Extracting data from %s projects", len(finished_projects))
+            logger.info("%s projects are failing", len(errored_projects))
 
     def get_report(self):
 

--- a/cyclonedx/constants.py
+++ b/cyclonedx/constants.py
@@ -1,4 +1,9 @@
 """ Constants to be used throughout the system"""
+from os import path
+
+PYTHON_LOGGING_CONFIG = path.join(
+    path.dirname(path.dirname(__file__)), "python_logging.conf"
+)
 
 DT_API_PORT = 8080
 APP_PORT = 433

--- a/cyclonedx/handlers/common.py
+++ b/cyclonedx/handlers/common.py
@@ -1,10 +1,11 @@
 """
 -> Common Handler Functions
 """
-
 import importlib.resources as pr
+import logging
 from io import StringIO
 from json import dumps, loads
+from logging import config
 from typing import Union
 
 import boto3
@@ -12,21 +13,24 @@ from boto3 import resource
 
 import cyclonedx.schemas as schemas
 from cyclonedx.clients import HarborDBClient
-from cyclonedx.model import generate_model_id
 from cyclonedx.constants import (
+    PYTHON_LOGGING_CONFIG,
     S3_META_CODEBASE_KEY,
     S3_META_PROJECT_KEY,
     S3_META_TEAM_KEY,
     SBOM_BUCKET_NAME_KEY,
     SBOM_S3_KEY,
 )
-from cyclonedx.model import EntityType, HarborModel
+from cyclonedx.model import EntityType, HarborModel, generate_model_id
 from cyclonedx.model.codebase import CodeBase
 from cyclonedx.model.member import Member
 from cyclonedx.model.project import Project
 from cyclonedx.model.team import Team
 
 team_schema = loads(pr.read_text(schemas, "team.schema.json"))
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 class ContextKeys:
@@ -160,8 +164,8 @@ def print_values(event: dict, context: dict) -> None:
     -> Prints the values of the event and context
     """
 
-    print(f"<EVENT event=|{dumps(event, indent=2)}| />")
-    print(f"<CONTEXT context=|{context}| />")
+    logger.info("EVENT event= %s", dumps(event, indent=2))
+    logger.info("CONTEXT context %s", context)
 
 
 def _get_request_body_as_dict(event: dict) -> dict:
@@ -240,7 +244,7 @@ def _to_codebases(team_id: str, project_id: str, codebases: list[dict]):
             for codebase in codebases
         ]
     except KeyError as ke:
-        print(f"KeyError trying to create CodeBase: {ke}")
+        logger.info("KeyError trying to create CodeBase: %s", ke)
         return []
 
 
@@ -269,7 +273,7 @@ def _to_projects(team_id: str, projects: list[dict]):
 
         return ret_projects
     except KeyError as ke:
-        print(f"KeyError trying to create Project: {ke}")
+        logger.info("KeyError trying to create Project: %s", ke)
         return []
 
 

--- a/cyclonedx/handlers/dt_interface_handler.py
+++ b/cyclonedx/handlers/dt_interface_handler.py
@@ -1,8 +1,10 @@
 """
 -> Module for the Dependency Track Interface Handler
 """
+import logging
 from io import StringIO
 from json import dumps
+from logging import config
 
 from boto3 import resource
 
@@ -13,7 +15,10 @@ from cyclonedx.clients.dependency_track.dependency_track import (
     __upload_sbom,
     __validate,
 )
-from cyclonedx.constants import SBOM_BUCKET_NAME_KEY, SBOM_S3_KEY
+from cyclonedx.constants import PYTHON_LOGGING_CONFIG, SBOM_BUCKET_NAME_KEY, SBOM_S3_KEY
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 def dt_interface_handler(event: dict = None, context: dict = None):
@@ -26,7 +31,7 @@ def dt_interface_handler(event: dict = None, context: dict = None):
 
     s3_resource = resource("s3")
 
-    print(f"<Event event='{event}' />")
+    logger.info("Event event= %s", event)
 
     # Currently making sure it isn't empty
     __validate(event)
@@ -64,6 +69,6 @@ def dt_interface_handler(event: dict = None, context: dict = None):
         Body=findings_bytes,
     )
 
-    print(f"Findings are in the s3 bucket: {bucket_name}/{findings_key}")
+    logger.info("Findings are in the s3 bucket: %s, %s", bucket_name, findings_key)
 
     return findings_key

--- a/cyclonedx/handlers/enrichment_ingress_handler.py
+++ b/cyclonedx/handlers/enrichment_ingress_handler.py
@@ -1,7 +1,9 @@
 """
 -> Module for the Enrichment Ingress Handler
 """
+import logging
 from json import dumps
+from logging import config
 
 import boto3
 from jsonschema.exceptions import ValidationError
@@ -11,9 +13,13 @@ from cyclonedx.constants import (
     EVENT_BUS_DETAIL_TYPE,
     EVENT_BUS_NAME,
     EVENT_BUS_SOURCE,
+    PYTHON_LOGGING_CONFIG,
     SBOM_BUCKET_NAME_KEY,
     SBOM_S3_KEY,
 )
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 def enrichment_ingress_handler(event: dict = None, context: dict = None):
@@ -28,7 +34,7 @@ def enrichment_ingress_handler(event: dict = None, context: dict = None):
 
     records: list = __get_records_from_event(event)
 
-    print(f"<Records records={records}>")
+    logger.info("Records records= %s", records)
 
     for record in records:
 
@@ -45,7 +51,7 @@ def enrichment_ingress_handler(event: dict = None, context: dict = None):
         # try:
         #     enrichment_id = s3_object["Metadata"][ENRICHMENT_ID]
         # except KeyError as key_err:
-        #     print(f"<s3Object object={s3_object} />")
+        #     logger.info("s3Object object= %s", s3_object)} />")
         #     enrichment_id = f"ERROR: {key_err}"
 
         response = eb_client.put_events(
@@ -66,4 +72,4 @@ def enrichment_ingress_handler(event: dict = None, context: dict = None):
             ],
         )
 
-        print(f"<PutEventsResponse response='{response}' />")
+        logger.info("PutEventsResponse response= %s", response)

--- a/cyclonedx/handlers/ingress.py
+++ b/cyclonedx/handlers/ingress.py
@@ -2,7 +2,9 @@
 -> Module to house the SBOM Ingress Handler
 """
 import datetime
+import logging
 from json import dumps
+from logging import config
 from os import environ
 from uuid import uuid4
 
@@ -14,6 +16,7 @@ from cyclonedx.clients.dependency_track.dependency_track import (
     __get_body_from_event,
 )
 from cyclonedx.constants import (
+    PYTHON_LOGGING_CONFIG,
     S3_META_CODEBASE_KEY,
     S3_META_PROJECT_KEY,
     S3_META_TEAM_KEY,
@@ -21,6 +24,9 @@ from cyclonedx.constants import (
     SBOM_BUCKET_NAME_KEY,
 )
 from cyclonedx.core import CycloneDxCore
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 def sbom_ingress_handler(event: dict = None, context: dict = None) -> dict:
@@ -44,11 +50,11 @@ def sbom_ingress_handler(event: dict = None, context: dict = None) -> dict:
     # Get the bucket name from the environment variable
     # This is set during deployment
     bucket_name = environ[SBOM_BUCKET_NAME_KEY]
-    print(f"Bucket name from env(SBOM_BUCKET_NAME_EV): {bucket_name}")
+    logger.info("Bucket name from env(SBOM_BUCKET_NAME_EV) %s", bucket_name)
 
     # Generate the name of the object in S3
     key = f"sbom-{uuid4()}"
-    print(f"Putting object in S3 with key: {key}")
+    logger.info("Putting object in S3 with key: %s", key)
 
     # Create an instance of the Python CycloneDX Core
     core = CycloneDxCore()

--- a/cyclonedx/handlers/sbom_generate_handler.py
+++ b/cyclonedx/handlers/sbom_generate_handler.py
@@ -1,11 +1,18 @@
 """
 -> Module to house the SBOM Generator Handler
 """
+import logging
+from logging import config
+
+from cyclonedx.constants import PYTHON_LOGGING_CONFIG
 from cyclonedx.handlers.common import (
     QueryStringKeys,
     _extract_value_from_qs,
     harbor_response,
 )
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 def sbom_generate_handler(event: dict = None, context: dict = None) -> dict:
@@ -22,8 +29,8 @@ def sbom_generate_handler(event: dict = None, context: dict = None) -> dict:
         project_id: str = _extract_value_from_qs(QueryStringKeys.PROJECT_ID, event)
         token: str = event["authorizationToken"]
 
-        print(team_id)
-        print(project_id)
+        logger.info(team_id)
+        logger.info(project_id)
 
         if token is None:
             return harbor_response(403, response)

--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -6,13 +6,19 @@ from __future__ import annotations
 
 import abc
 import copy
+import logging
 from enum import Enum
+from logging import config
 from uuid import uuid4
 
 from cyclonedx.constants import (
     HARBOR_TEAMS_TABLE_PARTITION_KEY,
     HARBOR_TEAMS_TABLE_SORT_KEY,
+    PYTHON_LOGGING_CONFIG,
 )
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 def generate_model_id(model_id: str = ""):
@@ -238,7 +244,9 @@ class HarborModel:
             (entity_type, _) = EntityKey.split_entity_key(instance.entity_key)
             self._children[entity_type].append(instance)
         except KeyError:
-            print(f"This class has no children of {entity_type} type, moving on...")
+            logger.info(
+                self, f"This class has no children of {entity_type} type, moving on..."
+            )
 
     @classmethod
     @abc.abstractmethod

--- a/deploy/build.py
+++ b/deploy/build.py
@@ -1,12 +1,18 @@
 """ This Module has functions that can be run using Poetry to perform build tasks"""
-
-from shutil import rmtree
+import logging
 from inspect import stack
+from logging import config
 from optparse import OptionParser
 from os import system
+from shutil import rmtree
+
+from deploy.constants import PYTHON_LOGGING_CONFIG
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 parser = OptionParser("usage: %prog [options]")
-parser.add_option('--ui', dest="ui", help='ui flag', action="store_true")
+parser.add_option("--ui", dest="ui", help="ui flag", action="store_true")
 
 
 def install():
@@ -109,7 +115,7 @@ def clean():
         try:
             rmtree(unwanted_dir)
         except OSError as os_error:
-            print("Error: %s : %s" % (unwanted_dir, os_error.strerror))
+            logger.info("Error: %s", (unwanted_dir, os_error.strerror))
     run_ui_if_enabled()
 
 
@@ -131,10 +137,11 @@ def run_ui_if_enabled():
         poetry run <install,run,lint,test> --ui
     """
 
+    # pylint: disable = W0612
     (options, args) = parser.parse_args()
     caller = stack()[1][3]
 
     if options.ui:
         method = caller + "_ui"
-        print("\nRunning " + caller + " for UI...\n")
+        logger.info("Running caller for UI %s", caller)
         globals()[method]()

--- a/deploy/constants.py
+++ b/deploy/constants.py
@@ -1,5 +1,5 @@
 """ This module has constants throughout the build code """
-from os import getenv
+from os import getenv, path
 
 import aws_cdk.aws_ec2 as ec2
 import aws_cdk.aws_lambda as lambda_
@@ -13,6 +13,9 @@ regionCodes = {
 
 # General
 SBOM_API_PYTHON_RUNTIME = lambda_.Runtime.PYTHON_3_9
+PYTHON_LOGGING_CONFIG = path.join(
+    path.dirname(path.dirname(__file__)), "python_logging.conf"
+)
 
 # AWS
 AWS_PROFILE = getenv("AWS_PROFILE")
@@ -22,7 +25,10 @@ AWS_REGION_SHORT = regionCodes.get(AWS_REGION)
 ENVIRONMENT = getenv("ENVIRONMENT") or "sandbox"
 
 # CMS
-CMS_PERMISSION_BOUNDARY_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:policy/cms-cloud-admin/ct-ado-poweruser-permissions-boundary-policy"
+CMS_PERMISSION_BOUNDARY_ARN = (
+    f"arn:aws:iam::{AWS_ACCOUNT_ID}:policy/cms-cloud-admin/"
+    f"ct-ado-poweruser-permissions-boundary-policy"
+)
 CMS_ROLE_PATH = "/delegatedadmin/developer/"
 
 # Cognito

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -1,4 +1,6 @@
 """ This module is the start of the deployment for SBOM-API """
+import logging
+from logging import config
 from os import system
 
 import aws_cdk as cdk
@@ -12,6 +14,7 @@ from deploy.constants import (
     CMS_PERMISSION_BOUNDARY_ARN,
     CMS_ROLE_PATH,
     ENVIRONMENT,
+    PYTHON_LOGGING_CONFIG,
 )
 from deploy.role_aspect import RoleAspect
 from deploy.stacks import (
@@ -25,6 +28,9 @@ from deploy.stacks import (
 from deploy.stacks.SBOMIngressApiStack import SBOMIngressApiStack
 from deploy.util import DynamoTableManager
 from tests.data.create_cognito_users import test_create_cognito_users
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 def dodep() -> None:
@@ -96,7 +102,7 @@ def dodep() -> None:
         pilot_stack.add_pilot_route(ingress_api_stack.api)
 
         if AWS_PROFILE in ("cms-dev", "cms-prod"):
-            print(
+            logger.info(
                 "Deploying to CMS. Applying permissions boundary, and path, to all roles!"
             )
             for stack in stacks:

--- a/deploy/role_aspect.py
+++ b/deploy/role_aspect.py
@@ -1,44 +1,56 @@
-from typing import Union
+"""
+-> Module for RoleAspect class
+"""
+import logging
+from logging import config
 
-import jsii
 import aws_cdk as cdk
 import constructs
+import jsii
 from aws_cdk import aws_iam
+from jsii._kernel import Kernel, ObjRef
 from jsii._reference_map import _refs
 from jsii._utils import Singleton
+
+from deploy.constants import PYTHON_LOGGING_CONFIG
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 
 
 @jsii.implements(cdk.IAspect)
 class RoleAspect:
     """
-    This aspect finds all aws_iam.Role objects in a node (ie. CDK stack) and sets permission boundary to the given ARN.
+    This aspect finds all aws_iam.Role objects in a node (ie. CDK stack)
+     and sets permission boundary to the given ARN.
     """
 
     def __init__(self, permission_boundary_arn: str, path: str) -> None:
         """
-        :param permission_boundary_arn: Either aws_iam.ManagedPolicy object or managed policy's ARN string
+        :param permission_boundary_arn: Either aws_iam.ManagedPolicy
+        object or managed policy's ARN string
         """
         self.permission_boundary_arn = permission_boundary_arn
         self.path = path
 
     def visit(self, construct_ref: constructs.IConstruct) -> None:
         """
-        construct_ref only contains a string reference to an object. To get the actual object, we need to resolve it using JSII mapping.
+        construct_ref only contains a string reference to an object. To get the actual object,
+         we need to resolve it using JSII mapping.
         :param construct_ref: ObjRef object with string reference to the actual object.
         :return: None
         """
-        if isinstance(construct_ref, jsii._kernel.ObjRef) and hasattr(
-            construct_ref, "ref"
-        ):
+        if isinstance(construct_ref, ObjRef) and hasattr(construct_ref, "ref"):
+            # pylint: disable = W0212
             kernel = Singleton._instances[
-                jsii._kernel.Kernel
+                Kernel
             ]  # The same object is available as: jsii.kernel
             resolve = _refs.resolve(kernel, construct_ref)
         else:
             resolve = construct_ref
 
         def _walk(obj):
-            # print(obj)
+            # logger.info(obj)
             if isinstance(obj, aws_iam.Role):
                 cfn_role = obj.node.find_child("Resource")
                 cfn_role.add_property_override(
@@ -46,7 +58,7 @@ class RoleAspect:
                 )
                 cfn_role.add_property_override("Path", self.path)
             elif isinstance(obj, aws_iam.CfnRole):
-                # print(obj.)
+                # logger.info(obj.)
                 obj.permissions_boundary = self.permission_boundary_arn
                 obj.path = self.path
             else:

--- a/deploy/util/SBOMHarborCertificate.py
+++ b/deploy/util/SBOMHarborCertificate.py
@@ -1,18 +1,26 @@
-
 """ SBOM HarborCertificate has classes and methods that
 register a FQDN with a certificate with Route53 """
-
+import logging
 import os
+from logging import config
+
 import constructs
-from aws_cdk import (
-    aws_route53 as r53,
-    aws_certificatemanager as acm,
-    aws_route53_targets as r53_targets,
-    aws_cloudfront as cf,
-)
+from aws_cdk import aws_certificatemanager as acm
+from aws_cdk import aws_cloudfront as cf
+from aws_cdk import aws_route53 as r53
+from aws_cdk import aws_route53_targets as r53_targets
 from aws_cdk.aws_cloudfront import ViewerCertificate
 
+from deploy.constants import PYTHON_LOGGING_CONFIG
+
+config.fileConfig(PYTHON_LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
+
+
 def get_env_var(key: str) -> str:
+    """
+    returns environment variable
+    """
     err = KeyError(f"Unable to find value for {key}")
     try:
         val = os.environ[key]
@@ -20,24 +28,25 @@ def get_env_var(key: str) -> str:
             raise err
 
         return val
-    except KeyError:
-        raise err
+    except KeyError as keyError:
+        raise keyError
 
-class Cert(object):
+
+class Cert:
 
     """
-        Class to manage adding a domain name to CloudFront and
-        associating a Certificate.
+    Class to manage adding a domain name to CloudFront and
+    associating a Certificate.
 
-        This class requires some loaded environment variables:
-        * SBOM_HARBOR_CERT_ENABLED: If true, this class will add the
-          FQDN to the CloudFront Distribution and associate the Certificate
-        * SBOM_HARBOR_CERT_FQDN: The fully qualified domain name that should
-          be added to the CloudFront Distribution
-        * SBOM_HARBOR_CERT_HZONE_ID: The ID of the Hosted Zone in Route53. This class
-          needs to dynamically add a Host(A) record to route the FQDN to the CloudFront
-          generated FQDN.
-        * SBOM_HARBOR_CERT_ARN: The ARN of the certificate in AWS Certificate Manager.
+    This class requires some loaded environment variables:
+    * SBOM_HARBOR_CERT_ENABLED: If true, this class will add the
+      FQDN to the CloudFront Distribution and associate the Certificate
+    * SBOM_HARBOR_CERT_FQDN: The fully qualified domain name that should
+      be added to the CloudFront Distribution
+    * SBOM_HARBOR_CERT_HZONE_ID: The ID of the Hosted Zone in Route53. This class
+      needs to dynamically add a Host(A) record to route the FQDN to the CloudFront
+      generated FQDN.
+    * SBOM_HARBOR_CERT_ARN: The ARN of the certificate in AWS Certificate Manager.
     """
 
     def __init__(self, scope: constructs.Construct):
@@ -48,45 +57,58 @@ class Cert(object):
         try:
             self.enabled = bool(get_env_var("SBOM_HARBOR_CERT_ENABLED"))
         except KeyError:
-            print("SBOM Harbor Certificate is DISABLED")
+            logger.info("SBOM Harbor Certificate is DISABLED")
             self.enabled = False
 
         if self.enabled:
-            print(f"SBOM Harbor Certificate is ENABLED")
+            logger.info("SBOM Harbor Certificate is ENABLED")
 
             try:
                 self.domain_name = get_env_var("SBOM_HARBOR_CERT_FQDN")
                 self.hosted_zone_id = get_env_var("SBOM_HARBOR_CERT_HZONE_ID")
                 self.cert_arn = get_env_var("SBOM_HARBOR_CERT_ARN")
 
-                print(f"Data: {self.domain_name}, {self.hosted_zone_id}, {self.cert_arn}")
+                logger.info(
+                    "Data: %s, %s, %s",
+                    self.domain_name,
+                    self.hosted_zone_id,
+                    self.cert_arn,
+                )
 
                 self.my_hosted_zone = r53.HostedZone.from_hosted_zone_attributes(
-                    self.scope, "SBOMHarborZone",
+                    self.scope,
+                    "SBOMHarborZone",
                     hosted_zone_id=self.hosted_zone_id,
                     zone_name=self.domain_name,
                 )
 
                 self.acm_cert = acm.Certificate.from_certificate_arn(
-                    self.scope, "SBOMHarborCert",
-                    certificate_arn=self.cert_arn
+                    self.scope, "SBOMHarborCert", certificate_arn=self.cert_arn
                 )
             except KeyError as ke:
-                print(f"KeyError acquiring cert values, {ke} is missing")
+                logger.info("KeyError acquiring cert values, %s is missing", ke)
                 self.enabled = False
 
     def get_viewer_cert(self):
+        """
+        -> Returns viewer certificate
+        """
         return ViewerCertificate.from_acm_certificate(
-            self.acm_cert, aliases=[self.domain_name],
+            self.acm_cert,
+            aliases=[self.domain_name],
             security_policy=cf.SecurityPolicyProtocol.TLS_V1_2_2021,
             ssl_method=cf.SSLMethod.SNI,
         )
 
     def create_host_record(self, dist: cf.CloudFrontWebDistribution):
+        """
+        -> Creates a host record
+        """
         if self.enabled:
             cf_target = r53_targets.CloudFrontTarget(dist)
             r53.ARecord(
-                self.scope, "SBOMAliasRecord",
+                self.scope,
+                "SBOMAliasRecord",
                 zone=self.my_hosted_zone,
-                target=r53.RecordTarget.from_alias(cf_target)
+                target=r53.RecordTarget.from_alias(cf_target),
             )

--- a/python_logging.conf
+++ b/python_logging.conf
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=console
+
+[formatters]
+keys=std_out
+
+[logger_root]
+handlers = console
+level = DEBUG
+
+[handler_console]
+class = logging.StreamHandler
+level = DEBUG
+formatter = std_out
+
+[formatter_std_out]
+format = %(asctime)s : %(levelname)s : %(module)s : %(funcName)s : %(lineno)d : (Process Details : (%(process)d, %(processName)s), Thread Details : (%(thread)d, %(threadName)s))\nLog : %(message)s
+datefmt = %d-%m-%Y %I:%M:%S


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/ISPGCASP/) to the PR title like this `[ISPGCASP-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

This changes all existing print statements to use python logging. This sets all statements to be INFO, the setting for a particular log  may need to be changed as we move forward.

Also note that this touched a large amount of files and as a result triggered a significant amount of linting changes as well.

### Added

python_logging.conf file that has the default settings for all python logging in our project

### Changed

- Migrated all python "print" statements to use logger.info("my statement")
- Many of the modified logging statements failed in the linting stage as they were not using lazy string formatting. This required me to slightly modify a good portion of our logs to use lazy strings.


## How to test

Instructions on how to test the changes. This is not exhaustive list of ways you should test this PR.
