### PR TITLE
chore(ui): change jest to ts; mock fetch beforeEach [ISPGCASP-1108]

### DIFF
--- a/ui/packages/sbom/craco.config.js
+++ b/ui/packages/sbom/craco.config.js
@@ -56,7 +56,7 @@ module.exports = {
       moduleNameMapper: { '^@/(.*)$': '<rootDir>/src/$1' },
       roots: ['<rootDir>/src/'],
       testMatch: ['<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'],
-      setupFilesAfterEnv: '<rootDir>/jest.setup.js',
+      setupFilesAfterEnv: '<rootDir>/jest.setup.ts',
       collectCoverage: true,
       collectCoverageFrom: ['<rootDir>/**/*.{js,jsx,ts,tsx}'],
       coverageReporters: ['json', 'lcov', 'text'],

--- a/ui/packages/sbom/jest.setup.ts
+++ b/ui/packages/sbom/jest.setup.ts
@@ -11,28 +11,21 @@ import '@testing-library/jest-dom/extend-expect'
  * @returns  {Promise<Object>} the mocked fetch response per endpoint
  */
 async function mockFetch(url, config) {
-  // sbom upload endpoint
-  if (url.includes('/sbom')) {
-    return {
-      json: async () => ({}),
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-    }
-  }
+  return Promise.resolve({
+    json: async () => ({}),
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+  })
 }
 
-beforeAll(() => {
+beforeEach(() => {
   /**
-   * Mock `window.fetch` for tests
+   * Mock `global.fetch` for tests
    * @see {@link https://jestjs.io/docs/en/manual-mocks}
    */
   // assuming jest's resetMocks is configured to "true"
   // so we don't need to worry about cleanup. also assumes
   // that a fetch polyfill like `whatwg-fetch` is loaded.
-  jest.spyOn(global, 'fetch')
-})
-
-beforeEach(() => {
-  fetch.mockImplementation(mockFetch)
+  jest.spyOn(global, 'fetch').mockImplementation(mockFetch as jest.Mock)
 })

--- a/ui/packages/sbom/src/api/createToken.test.tsx
+++ b/ui/packages/sbom/src/api/createToken.test.tsx
@@ -1,12 +1,6 @@
 import createToken from './createToken'
 
 test('calls makes a fetch request', () => {
-  // @ts-ignore
-  window.fetch.mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({}),
-  })
-
   const date = new Date()
   // TODO: undo this once the API gets corrected
   const expires = date.toISOString().replace(/Z$/, '') as TDateISOWithoutZ
@@ -18,7 +12,7 @@ test('calls makes a fetch request', () => {
     teamId: 'some-team',
   })
 
-  expect(window.fetch).toHaveBeenCalledTimes(1)
+  expect(global.fetch).toHaveBeenCalledTimes(1)
 
   // TODO: add a test to verify the request verb and path
 })

--- a/ui/packages/sbom/src/api/deleteToken.test.tsx
+++ b/ui/packages/sbom/src/api/deleteToken.test.tsx
@@ -1,16 +1,10 @@
 import deleteToken from './deleteToken'
 
 test('calls makes a fetch request', () => {
-  // @ts-ignore
-  window.fetch.mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({}),
-  })
-
   deleteToken({
     jwtToken: 'some-token',
     teamId: 'some-team',
     tokenId: 'some-token',
   })
-  expect(window.fetch).toHaveBeenCalledTimes(1)
+  expect(global.fetch).toHaveBeenCalledTimes(1)
 })

--- a/ui/packages/sbom/src/api/updateToken.test.tsx
+++ b/ui/packages/sbom/src/api/updateToken.test.tsx
@@ -1,12 +1,6 @@
 import updateToken from './updateToken'
 
 test('calls makes a fetch request', () => {
-  // @ts-ignore
-  window.fetch.mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({}),
-  })
-
   updateToken({
     jwtToken: 'some-token',
     teamId: 'some-team',
@@ -17,5 +11,5 @@ test('calls makes a fetch request', () => {
     },
   })
 
-  expect(window.fetch).toHaveBeenCalledTimes(1)
+  expect(global.fetch).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
## Summary

Improves the setup of UI tests by changing jest's setup file to typescript. Also changes the mocking of `global.fetch` to `beforeEach` instead of `beforeAll`, which prevents the `mock.called` counts from carrying over between test runs.

- Closes [ISPGCASP-1108](https://jiraent.cms.gov/browse/ISPGCASP-1108)

## Changed

- changes the mocking of `global.fetch` to `beforeEach` instead of `beforeAll`
- changes occurrences of `window.fetch` to `global.fetch` in tests

## Removed

- removes re-mocked instances of `window.fetch` in tests

## How to test

- `cd ui && yarn test`