### PR TITLE
chore(ui): add helper to convert timestamps [ISPGCASP-1109]

### DIFF
--- a/ui/packages/sbom/src/utils/__test__/formatTimestampForServer.test.ts
+++ b/ui/packages/sbom/src/utils/__test__/formatTimestampForServer.test.ts
@@ -1,0 +1,13 @@
+import formatTimestampForServer from '@/utils/formatTimestampForServer'
+
+const input = '2023-01-01T00:00:00.000Z'
+
+test('should return a timestamp formatted without the "Z"', () => {
+  const result = formatTimestampForServer(0, new Date(input))
+  expect(result).toEqual('2023-01-01T00:00:00.000')
+})
+
+test('should add the number of days to the date', () => {
+  const result = formatTimestampForServer(1, new Date(input))
+  expect(result).toEqual('2023-01-02T00:00:00.000')
+})

--- a/ui/packages/sbom/src/utils/formatTimestampForServer.ts
+++ b/ui/packages/sbom/src/utils/formatTimestampForServer.ts
@@ -1,0 +1,17 @@
+import dateAsISOWithoutZ from '@/utils/dateAsISOWithoutZ'
+
+/**
+ * Temporary helper function until timestamps are fixed on the server..
+ * @module @cyclonedx/ui/sbom/utils/formatTimestampForServer
+ * @param {Date} date The date to format.
+ * @param {number} daysToAdd The number of days to add to the date.
+ * @returns {TDateISOWithoutZ} The formatted date with the "Z" ending removed.
+ */
+const formatTimestampForServer = (
+  daysToAdd: number,
+  date: Date = new Date()
+): TDateISOWithoutZ => {
+  return dateAsISOWithoutZ(new Date(date.setDate(date.getDate() + daysToAdd)))
+}
+
+export default formatTimestampForServer

--- a/ui/packages/sbom/src/views/Dashboard/Team/components/TokenCreateDialog.tsx
+++ b/ui/packages/sbom/src/views/Dashboard/Team/components/TokenCreateDialog.tsx
@@ -16,8 +16,8 @@ import useAlert from '@/hooks/useAlert'
 import { useDialog } from '@/hooks/useDialog'
 import authLoader from '@/router/authLoader'
 import { Token } from '@/types'
-import dateAsISOWithoutZ from '@/utils/dateAsISOWithoutZ'
 import TokenViewDialog from '@/views/Dashboard/Team/components/TokenViewDialog'
+import formatTimestampForServer from '@/utils/formatTimestampForServer'
 
 enum ExpirationOptions {
   SEVEN_DAYS = '7 days',
@@ -30,19 +30,14 @@ enum ExpirationOptions {
   // CUSTOM = 'Custom',
 }
 
-const getExpirationDate = (daysToAdd: number): TDateISOWithoutZ => {
-  const date = new Date()
-  return dateAsISOWithoutZ(new Date(date.setDate(date.getDate() + daysToAdd)))
-}
-
 // FIXME: copy pasta shame
 const ExpirationValues = {
-  SEVEN_DAYS: () => getExpirationDate(7),
-  THIRTY_DAYS: () => getExpirationDate(30),
-  SIXTY_DAYS: () => getExpirationDate(60),
-  NINETY_DAYS: () => getExpirationDate(90),
-  SIX_MONTHS: () => getExpirationDate(182),
-  ONE_YEAR: () => getExpirationDate(365),
+  SEVEN_DAYS: () => formatTimestampForServer(7),
+  THIRTY_DAYS: () => formatTimestampForServer(30),
+  SIXTY_DAYS: () => formatTimestampForServer(60),
+  NINETY_DAYS: () => formatTimestampForServer(90),
+  SIX_MONTHS: () => formatTimestampForServer(182),
+  ONE_YEAR: () => formatTimestampForServer(365),
   // TODO: implement datepicker for custom expiration
   // CUSTOM = 'Custom',
 }


### PR DESCRIPTION
## Summary

Implements a helper method for converting javascript ISO dates to Python accepted ISO dates.

- Closes [ISPGCASP-1109](https://jiraent.cms.gov/browse/ISPGCASP-1109)

## Changed

- uses method in `ui/packages/sbom/src/views/Dashboard/Team/components/TokenCreateDialog.tsx` to generate expiration dates.

## How to test

- `cd ui && yarn test`
- using the ui
    - `yarn start`
    - login
    - view a team
    - create a new token for that team
    - confirm that the expiration date is set to future date as expected