### PR TITLE
Base64 update to 0.21.0

### DIFF
--- a/harbor-rs/Cargo.toml
+++ b/harbor-rs/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { version = "1.2.2", features = ["serde", "v4"] }
 aquia = { path = "../../../aquia/aquia-rs" }
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 aws_lambda_events = "0.7.2"
-base64 = "0.13.1"
+base64 = "0.21.0"
 ctor = "0.1.26"
 dotenv = "0.15.0"
 tokio-test = "*"

--- a/harbor-rs/build.sh
+++ b/harbor-rs/build.sh
@@ -42,6 +42,7 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
     # cargo only supports --release flag for release
     # profiles. dev is implicit
     if [ "${PROFILE}" == "release" ]; then
+        echo "RUNNING: <cargo build ${CARGO_BIN_ARG} ${CARGO_FLAGS:-} --${PROFILE}>"
         cargo build ${CARGO_BIN_ARG} ${CARGO_FLAGS:-} --${PROFILE}
     else
         cargo build ${CARGO_BIN_ARG} ${CARGO_FLAGS:-}

--- a/harbor-rs/tests/common/mod.rs
+++ b/harbor-rs/tests/common/mod.rs
@@ -175,6 +175,9 @@ pub fn get_pilot_request() -> std::io::Result<PilotRequest> {
 #[async_std::test]
 #[ignore = "manual run only"]
 pub async fn save_test_fixtures() -> std::io::Result<()> {
+
+    use base64::{Engine as _, engine::{general_purpose}};
+
     let tuple = generate_pilot_apigw_request().await;
 
     assert!(!tuple.is_err(), "{:?}", tuple);
@@ -191,7 +194,7 @@ pub async fn save_test_fixtures() -> std::io::Result<()> {
     target_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     target_file.push("tests/fixtures/HARBOR_PILOT_REQUEST");
 
-    let secret = base64::encode(pilot_req);
+    let secret = general_purpose::STANDARD.encode(pilot_req);
     std::fs::write(target_file.as_path(), secret)
 }
 


### PR DESCRIPTION

## Summary

Simple update to the base64 dependency.  There was an API change and the code has been modified to take advantage. 

### Changed

The version of base64

## How to test

cargo test
