### PR TITLE
fix(ui): validate process.env [ISPGCASP-1113]

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,19 +66,18 @@ jobs:
           echo "npm --version: $(npm --version)"
           echo "yarn --version: $(yarn --version)"
 
-      - name: cache .yarn/
-        id: cache-yarn-cache
-        uses: actions/cache@v3
-        with:
-          path: .yarn/
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - name: cache node_modules/
+      - name: cache .yarn/
+        id: yarn-cache
         uses: actions/cache@v3
-        id: cache-node-modules
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-
 
       - name: Run yarn install
         run: CI=true yarn install

--- a/ui/global.d.ts
+++ b/ui/global.d.ts
@@ -1,3 +1,0 @@
-/**
- * @module @cyclonedx/ui/sbom/global.d.ts
- */

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "yarn workspace @cyclonedx/ui-sbom run clean",
     "build": "NODE_ENV=production yarn workspace @cyclonedx/ui-sbom run build",
-    "start": "NODE_ENV=development yarn workspace @cyclonedx/ui-sbom run start",
+    "start": "NODE_ENV=development ENVIRONMENT=local yarn workspace @cyclonedx/ui-sbom run start",
     "test": "NODE_ENV=test yarn workspace @cyclonedx/ui-sbom run test",
     "watch": "NODE_ENV=test yarn workspace @cyclonedx/ui-sbom run watch",
     "check": "yarn workspace @cyclonedx/ui-sbom run check",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "scripts": {
     "clean": "yarn workspace @cyclonedx/ui-sbom run clean",
-    "build": "yarn workspace @cyclonedx/ui-sbom run build",
-    "test": "yarn workspace @cyclonedx/ui-sbom run test",
-    "start": "yarn workspace @cyclonedx/ui-sbom run start",
-    "watch": "yarn workspace @cyclonedx/ui-sbom run watch",
+    "build": "NODE_ENV=production yarn workspace @cyclonedx/ui-sbom run build",
+    "start": "NODE_ENV=development yarn workspace @cyclonedx/ui-sbom run start",
+    "test": "NODE_ENV=test yarn workspace @cyclonedx/ui-sbom run test",
+    "watch": "NODE_ENV=test yarn workspace @cyclonedx/ui-sbom run watch",
     "check": "yarn workspace @cyclonedx/ui-sbom run check",
     "fix": "run-p 'fix:js' 'fix:other'",
     "fix:js": "yarn run lint:js --fix",
@@ -36,6 +36,7 @@
     "**/{json,md,yaml,yml}": "yarn lint:other"
   },
   "devDependencies": {
+    "@types/dotenv-webpack": "^7.0.3",
     "@types/jest": "29.2.5",
     "@types/lodash": "4.14.191",
     "@types/node": "18.11.18",

--- a/ui/packages/sbom/craco.config.ts
+++ b/ui/packages/sbom/craco.config.ts
@@ -5,10 +5,10 @@
 if (process.env.NODE_ENV === 'test') {
   process.env.ENVIRONMENT = 'test'
   process.env.AWS_REGION = 'us-east-1'
-  process.env.CF_DOMAIN = 'localhost:3000'
-  process.env.API_URL = `http://${process.env.CF_DOMAIN}`
   process.env.USER_POOL_ID = 'us-east-1_123456789'
   process.env.USER_POOL_CLIENT_ID = '1234567890123456789012'
+  process.env.CF_DOMAIN = 'localhost:3000'
+  process.env.API_URL = 'http://localhost:3000/api/v1'
 }
 
 import { resolve } from 'path'

--- a/ui/packages/sbom/declaration.d.ts
+++ b/ui/packages/sbom/declaration.d.ts
@@ -2,15 +2,34 @@
  * Global type declarations
  */
 
-// Image module declarations
+// ************************************
+// ** Module Declarations
+// ************************************
+
+// Image modules
 declare module '*.png'
 declare module '*.svg'
 
-// Style module declaration
+// Style modules
 declare module '*.css' {
   const classes: { [key: string]: string }
   export default classes
 }
+
+type ValidNodeEnvs = 'production' | 'test' | 'development'
+
+type ProcessEnv = {
+  NODE_ENV: ValidNodeEnvs
+  AWS_REGION: string
+  USER_POOL_ID: string
+  USER_POOL_CLIENT_ID: string
+  CF_DOMAIN: string
+}
+
+/**
+ * Generic Error Callback type
+ */
+type ErrorCallback = (err: Error) => void
 
 /**
  * Generalizable way to require at least one of a set of properties is provided.
@@ -40,11 +59,6 @@ type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
   }[Keys]
 
 /**
- * Generic Error Callback type
- */
-type ErrorCallbackType = (err: Error) => void
-
-/**
  * Date Interface
  */
 interface Date {
@@ -55,6 +69,9 @@ interface Date {
   toISOString(): TDateISO
 }
 
+/**
+ * Date strings
+ */
 type TYear = `${number}${number}${number}${number}`
 type TMonth = `${number}${number}`
 type TDay = `${number}${number}`

--- a/ui/packages/sbom/jest.setup.ts
+++ b/ui/packages/sbom/jest.setup.ts
@@ -6,11 +6,9 @@ import '@testing-library/jest-dom/extend-expect'
 
 /**
  * Create a mock fetch response per endpoint.
- * @param {URL | string} url the fetch request url
- * @param {Object} config the fetch request configuration
  * @returns  {Promise<Object>} the mocked fetch response per endpoint
  */
-async function mockFetch(url, config) {
+async function mockFetch() {
   return Promise.resolve({
     json: async () => ({}),
     ok: true,

--- a/ui/packages/sbom/src/api/updateTeam.test.ts
+++ b/ui/packages/sbom/src/api/updateTeam.test.ts
@@ -1,8 +1,9 @@
 import updateTeam from '@/api/updateTeam'
-import { BuildTool, CodebaseLanguage } from '@/types'
 import getFutureDate from '@/utils/getFutureDate'
+import { BuildTool, CodebaseLanguage } from '@/types'
 
-const apiUrl = 'https://localhost:3000/api/v1/team'
+// test environment variables are set in craco.config.ts
+const apiUrl = `${process.env.API_URL}/team`
 
 const member = {
   isTeamLead: true,
@@ -68,15 +69,15 @@ test('calls makes a fetch request with correct body', async () => {
 })
 
 test('creates a new team on the update team route', async () => {
+  const expectedUrl = `${apiUrl}?children=true`
   await updateTeam(updateTeamParams)
   const [[requestUrl]] = (global.fetch as jest.Mock).mock.calls
-  const desiredUrl = `${apiUrl}?children=true`
-  expect(requestUrl.toString()).toStrictEqual(desiredUrl)
+  expect(requestUrl.toString()).toStrictEqual(expectedUrl)
 })
 
 test('updates an existing team on the update team route', async () => {
+  const expectedUrl = `${apiUrl}/${teamId}?children=true`
   await updateTeam({ ...updateTeamParams, newTeamRouteMatch: false })
   const [[requestUrl]] = (global.fetch as jest.Mock).mock.calls
-  const desiredUrl = `${apiUrl}/${teamId}?children=true`
-  expect(requestUrl.toString()).toStrictEqual(desiredUrl)
+  expect(requestUrl.toString()).toStrictEqual(expectedUrl)
 })

--- a/ui/packages/sbom/src/hooks/useData.tsx
+++ b/ui/packages/sbom/src/hooks/useData.tsx
@@ -59,7 +59,7 @@ export const DataProvider = ({
         return
       }
 
-      const url = new URL(`${CONFIG.API_URL}/v1/teams`)
+      const url = new URL(`${CONFIG.API_URL}/teams`)
       url.searchParams.append('children', 'true')
 
       const teams = await fetch(url, {

--- a/ui/packages/sbom/src/types.ts
+++ b/ui/packages/sbom/src/types.ts
@@ -16,6 +16,7 @@ import {
  */
 export type AppConfig = {
   // Environment
+  ENVIRONMENT: string
   NODE_ENV: string
 
   // AWS

--- a/ui/packages/sbom/src/types.ts
+++ b/ui/packages/sbom/src/types.ts
@@ -15,15 +15,21 @@ import {
  * @see {@link @cyclonedx/ui-sbom/craco.config.js}
  */
 export type AppConfig = {
+  // Environment
+  NODE_ENV: string
+
+  // AWS
   AWS_REGION: string | 'us-east-1'
   CF_DOMAIN: string
+  USER_POOL_ID: string
+  USER_POOL_CLIENT_ID: string
+
+  // API
   API_URL: string
   TEAM_API_URL: string
   TEAMS_API_URL: string
   USER_API_URL: string
   USER_API_SEARCH_URL: string
-  USER_POOL_ID: string
-  USER_POOL_CLIENT_ID: string
 }
 
 export enum RouteIds {

--- a/ui/packages/sbom/src/utils/constants.ts
+++ b/ui/packages/sbom/src/utils/constants.ts
@@ -26,8 +26,8 @@ export const CONFIG = {
   AWS_REGION,
   USER_POOL_ID,
   USER_POOL_CLIENT_ID,
-  TEAM_API_URL: `${API_URL}/v1/team`,
-  TEAMS_API_URL: `${API_URL}/v1/teams`,
-  USER_API_URL: `${API_URL}/v1/user`,
-  USER_API_SEARCH_URL: `${API_URL}/v1/user/search`,
+  TEAM_API_URL: `${API_URL}/team`,
+  TEAMS_API_URL: `${API_URL}/teams`,
+  USER_API_URL: `${API_URL}/user`,
+  USER_API_SEARCH_URL: `${API_URL}/user/search`,
 } as AppConfig

--- a/ui/packages/sbom/src/utils/constants.ts
+++ b/ui/packages/sbom/src/utils/constants.ts
@@ -4,21 +4,30 @@
  * @exports storageTokenKeyName
  */
 import { AppConfig } from '@/types'
-import { validateEnvironment, validateURL } from '@/utils/validateEnv'
+import { validateEnvironment } from '@/utils/validateEnvironment'
 
-const ENV = validateEnvironment()
-
-const apiUrl = validateURL(`${ENV.CF_DOMAIN}/api`).toString()
+const {
+  ENVIRONMENT,
+  NODE_ENV,
+  API_URL,
+  AWS_REGION,
+  USER_POOL_ID,
+  USER_POOL_CLIENT_ID,
+} = validateEnvironment()
 
 /**
  * Set global configuration for the application provided by webpack (craco) at build time.
  * @see {@link @cyclonedx-python/ui/packages/sbom/craco.config.js}.
  */
 export const CONFIG = {
-  ...ENV,
-  API_URL: apiUrl,
-  TEAM_API_URL: `${apiUrl}/v1/team`,
-  TEAMS_API_URL: `${apiUrl}/v1/teams`,
-  USER_API_URL: `${apiUrl}/v1/user`,
-  USER_API_SEARCH_URL: `${apiUrl}/v1/user/search`,
+  ENVIRONMENT,
+  NODE_ENV,
+  API_URL,
+  AWS_REGION,
+  USER_POOL_ID,
+  USER_POOL_CLIENT_ID,
+  TEAM_API_URL: `${API_URL}/v1/team`,
+  TEAMS_API_URL: `${API_URL}/v1/teams`,
+  USER_API_URL: `${API_URL}/v1/user`,
+  USER_API_SEARCH_URL: `${API_URL}/v1/user/search`,
 } as AppConfig

--- a/ui/packages/sbom/src/utils/constants.ts
+++ b/ui/packages/sbom/src/utils/constants.ts
@@ -4,22 +4,21 @@
  * @exports storageTokenKeyName
  */
 import { AppConfig } from '@/types'
+import { validateEnvironment, validateURL } from '@/utils/validateEnv'
 
-// parse `CONFIG` from environment variables
-const apiUrl = `${process.env.CF_DOMAIN}/api`
+const ENV = validateEnvironment()
+
+const apiUrl = validateURL(`${ENV.CF_DOMAIN}/api`).toString()
 
 /**
  * Set global configuration for the application provided by webpack (craco) at build time.
  * @see {@link @cyclonedx-python/ui/packages/sbom/craco.config.js}.
  */
 export const CONFIG = {
-  CF_DOMAIN: process.env.CF_DOMAIN,
+  ...ENV,
   API_URL: apiUrl,
   TEAM_API_URL: `${apiUrl}/v1/team`,
   TEAMS_API_URL: `${apiUrl}/v1/teams`,
   USER_API_URL: `${apiUrl}/v1/user`,
   USER_API_SEARCH_URL: `${apiUrl}/v1/user/search`,
-  USER_POOL_ID: process.env.USER_POOL_ID,
-  USER_POOL_CLIENT_ID: process.env.USER_POOL_CLIENT_ID,
-  AWS_REGION: process.env.AWS_REGION,
 } as AppConfig

--- a/ui/packages/sbom/src/utils/harborRequest.ts
+++ b/ui/packages/sbom/src/utils/harborRequest.ts
@@ -38,7 +38,7 @@ const harborRequest = async ({
   }
 
   // create the url object with the path
-  const url = sanitizeUrl(`${CONFIG.API_URL}/v1/${path}`)
+  const url = sanitizeUrl(`${CONFIG.API_URL}/${path}`)
 
   // append the children=true query param to the url
   if (typeof children !== 'undefined' && children !== null) {

--- a/ui/packages/sbom/src/utils/validateEnv.ts
+++ b/ui/packages/sbom/src/utils/validateEnv.ts
@@ -1,0 +1,101 @@
+enum NodeEnv {
+  PRODUCTION = 'production',
+  TEST = 'test',
+  DEVELOPMENT = 'development',
+}
+
+enum EnvVars {
+  NODE_ENV = 'NODE_ENV',
+  AWS_REGION = 'AWS_REGION',
+  CF_DOMAIN = 'CF_DOMAIN',
+  USER_POOL_ID = 'USER_POOL_ID',
+  USER_POOL_CLIENT_ID = 'USER_POOL_CLIENT_ID',
+}
+
+type EnvVarsType = {
+  NODE_ENV: string
+  AWS_REGION: string
+  CF_DOMAIN: string
+  USER_POOL_ID: string
+  USER_POOL_CLIENT_ID: string
+}
+
+const requiredEnvVars = Object.values(EnvVars)
+
+const validNodeEnvs = Object.keys(NodeEnv)
+
+const ENV: EnvVarsType = {
+  NODE_ENV: process.env.NODE_ENV || '',
+  AWS_REGION: process.env.AWS_REGION || '',
+  CF_DOMAIN: process.env.CF_DOMAIN || '',
+  USER_POOL_ID: process.env.USER_POOL_ID || '',
+  USER_POOL_CLIENT_ID: process.env.USER_POOL_CLIENT_ID || '',
+}
+
+/**
+ * Validate the required environment variables.
+ * @returns {EnvVarsType} an object containing each
+ *  the required environment variables and their values.
+ */
+export function validateEnvironment(): EnvVarsType {
+  // ensure all required environment variables are set
+  const missing = requiredEnvVars.filter((e: EnvVars) => !ENV[e])
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`
+    )
+  }
+
+  try {
+    // ensure the CF_DOMAIN is valid
+    validateURL(ENV.CF_DOMAIN)
+  } catch (error) {
+    throw new Error(`Invalid CF_DOMAIN: ${ENV.CF_DOMAIN}`)
+  }
+
+  return {
+    NODE_ENV: ENV.NODE_ENV,
+    AWS_REGION: ENV.AWS_REGION,
+    CF_DOMAIN: ENV.CF_DOMAIN,
+    USER_POOL_ID: ENV.USER_POOL_ID,
+    USER_POOL_CLIENT_ID: ENV.USER_POOL_CLIENT_ID,
+  }
+}
+
+/**
+ * Validate a URL string.
+ * @param {String} url a url to validate
+ * @returns {URL} a URL object
+ */
+export function validateURL(url: string): URL {
+  try {
+    const trimmed = url.trim().replace(/"/, '')
+
+    if (!trimmed || typeof trimmed !== 'string') {
+      throw new Error('(must be a non-empty string)')
+    }
+
+    const protocol = trimmed.split('://')[0]
+    if (!protocol || !protocol.match(/^(http|https)$/)) {
+      throw new Error('(invalid protocol)')
+    }
+
+    return new URL(trimmed)
+  } catch (error) {
+    console.error(error)
+    throw new Error(`Invalid URL ${url} ${(error as Error).message}`)
+  }
+}
+
+/**
+ * Validate the NODE_ENV environment variable
+ */
+export function validateNodeEnv() {
+  if (!validNodeEnvs.includes(ENV.NODE_ENV)) {
+    const options = validNodeEnvs.join(', ')
+    throw new Error(
+      `Invalid NODE_ENV: ${ENV.NODE_ENV} (must be one of: ${options})`
+    )
+  }
+}

--- a/ui/packages/sbom/src/utils/validateEnvironment.ts
+++ b/ui/packages/sbom/src/utils/validateEnvironment.ts
@@ -14,6 +14,7 @@ enum EnvVars {
 
 type EnvVarsType = {
   NODE_ENV: string
+  ENVIRONMENT: string
   AWS_REGION: string
   CF_DOMAIN: string
   USER_POOL_ID: string
@@ -25,7 +26,8 @@ const requiredEnvVars = Object.values(EnvVars)
 const validNodeEnvs = Object.keys(NodeEnv)
 
 const ENV: EnvVarsType = {
-  NODE_ENV: process.env.NODE_ENV || '',
+  ENVIRONMENT: process.env.ENVIRONMENT || '',
+  NODE_ENV: process.env.NODE_ENV || 'development',
   AWS_REGION: process.env.AWS_REGION || '',
   CF_DOMAIN: process.env.CF_DOMAIN || '',
   USER_POOL_ID: process.env.USER_POOL_ID || '',
@@ -37,30 +39,39 @@ const ENV: EnvVarsType = {
  * @returns {EnvVarsType} an object containing each
  *  the required environment variables and their values.
  */
-export function validateEnvironment(): EnvVarsType {
+export function validateEnvironment(): EnvVarsType & { API_URL: string } {
   // ensure all required environment variables are set
   const missing = requiredEnvVars.filter((e: EnvVars) => !ENV[e])
-
   if (missing.length > 0) {
     throw new Error(
       `Missing required environment variables: ${missing.join(', ')}`
     )
   }
-
-  try {
-    // ensure the CF_DOMAIN is valid
-    validateURL(ENV.CF_DOMAIN)
-  } catch (error) {
-    throw new Error(`Invalid CF_DOMAIN: ${ENV.CF_DOMAIN}`)
-  }
-
   return {
     NODE_ENV: ENV.NODE_ENV,
+    ENVIRONMENT: ENV.ENVIRONMENT,
     AWS_REGION: ENV.AWS_REGION,
-    CF_DOMAIN: ENV.CF_DOMAIN,
     USER_POOL_ID: ENV.USER_POOL_ID,
     USER_POOL_CLIENT_ID: ENV.USER_POOL_CLIENT_ID,
+    CF_DOMAIN: ENV.CF_DOMAIN,
+    API_URL: getApiUrl(ENV.CF_DOMAIN).toString(),
   }
+}
+
+/**
+ * Ensure a cloudfront domain has a protocol.
+ * @param {string} cfDomain the cloudfront domain
+ * @returns the cloudfront domain with a protocol
+ */
+export function addProtocolToCloudfrontDomain(cfDomain: string): string {
+  const protocol = cfDomain.split('://')[0]
+  if (protocol && protocol.match(/^(http|https)$/)) {
+    return cfDomain
+  }
+  if (ENV.NODE_ENV === 'test') {
+    return `http://${cfDomain}`
+  }
+  return `https://${cfDomain}`
 }
 
 /**
@@ -68,23 +79,16 @@ export function validateEnvironment(): EnvVarsType {
  * @param {String} url a url to validate
  * @returns {URL} a URL object
  */
-export function validateURL(url: string): URL {
+export function getApiUrl(cfDomain: string): URL {
   try {
-    const trimmed = url.trim().replace(/"/, '')
-
+    const trimmed = cfDomain.trim().replace(/"/, '')
     if (!trimmed || typeof trimmed !== 'string') {
       throw new Error('(must be a non-empty string)')
     }
-
-    const protocol = trimmed.split('://')[0]
-    if (!protocol || !protocol.match(/^(http|https)$/)) {
-      throw new Error('(invalid protocol)')
-    }
-
-    return new URL(trimmed)
+    return new URL(addProtocolToCloudfrontDomain(`${trimmed}/api`))
   } catch (error) {
     console.error(error)
-    throw new Error(`Invalid URL ${url} ${(error as Error).message}`)
+    throw new Error(`Invalid URL ${cfDomain} ${(error as Error).message}`)
   }
 }
 

--- a/ui/packages/sbom/src/utils/validateEnvironment.ts
+++ b/ui/packages/sbom/src/utils/validateEnvironment.ts
@@ -1,3 +1,5 @@
+const API_ROUTE = '/api/v1'
+
 enum NodeEnv {
   PRODUCTION = 'production',
   TEST = 'test',
@@ -54,7 +56,7 @@ export function validateEnvironment(): EnvVarsType & { API_URL: string } {
     USER_POOL_ID: ENV.USER_POOL_ID,
     USER_POOL_CLIENT_ID: ENV.USER_POOL_CLIENT_ID,
     CF_DOMAIN: ENV.CF_DOMAIN,
-    API_URL: getApiUrl(ENV.CF_DOMAIN).toString(),
+    API_URL: `${getApiUrl(ENV.CF_DOMAIN).toString()}`,
   }
 }
 
@@ -63,7 +65,7 @@ export function validateEnvironment(): EnvVarsType & { API_URL: string } {
  * @param {string} cfDomain the cloudfront domain
  * @returns the cloudfront domain with a protocol
  */
-export function addProtocolToCloudfrontDomain(cfDomain: string): string {
+export function addProtocol(cfDomain: string): string {
   const protocol = cfDomain.split('://')[0]
   if (protocol && protocol.match(/^(http|https)$/)) {
     return cfDomain
@@ -85,7 +87,7 @@ export function getApiUrl(cfDomain: string): URL {
     if (!trimmed || typeof trimmed !== 'string') {
       throw new Error('(must be a non-empty string)')
     }
-    return new URL(addProtocolToCloudfrontDomain(`${trimmed}/api`))
+    return new URL(`${addProtocol(trimmed)}${API_ROUTE}`)
   } catch (error) {
     console.error(error)
     throw new Error(`Invalid URL ${cfDomain} ${(error as Error).message}`)

--- a/ui/packages/sbom/tsconfig.json
+++ b/ui/packages/sbom/tsconfig.json
@@ -25,6 +25,6 @@
     "strict": true,
     "types": ["node", "react", "react-dom", "jest", "@testing-library/jest-dom"]
   },
-  "include": ["src", "declaration.d.ts", "src/utils/validateEnv.ts"],
+  "include": ["src", "declaration.d.ts", "src/utils/validateEnvironment.ts"],
   "exclude": ["node_modules"]
 }

--- a/ui/packages/sbom/tsconfig.json
+++ b/ui/packages/sbom/tsconfig.json
@@ -15,13 +15,16 @@
     "moduleResolution": "node",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
-    "paths": { "@/*": ["src/*"] },
+    "paths": {
+      "@/*": ["src/*"],
+      "@config/*": ["config/*"]
+    },
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "types": ["node", "react", "react-dom", "jest", "@testing-library/jest-dom"]
   },
-  "include": ["src", "declaration.d.ts"],
+  "include": ["src", "declaration.d.ts", "src/utils/validateEnv.ts"],
   "exclude": ["node_modules"]
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4219,6 +4219,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cyclonedx/root@workspace:."
   dependencies:
+    "@types/dotenv-webpack": ^7.0.3
     "@types/jest": 29.2.5
     "@types/lodash": 4.14.191
     "@types/node": 18.11.18
@@ -5945,6 +5946,17 @@ __metadata:
   version: 0.3.3
   resolution: "@types/cookie@npm:0.3.3"
   checksum: 450c930d792a4fd5a93645b4123f02596368f904dbb1fe6fbb5043bce8f6ecf877a08511c6ba11c8e28168f62bc278e68d214f002fab927c9056c0bc69f21370
+  languageName: node
+  linkType: hard
+
+"@types/dotenv-webpack@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "@types/dotenv-webpack@npm:7.0.3"
+  dependencies:
+    "@types/node": "*"
+    tapable: ^2.2.0
+    webpack: ^5
+  checksum: db5401515df936615447364da0ced0ffcc458f83ac1a4f5c52d9285b88471c5fd9272d9bef56a2514a9b47cef482636f8032c346d1a2605b77b3a55741a7be0b
   languageName: node
   linkType: hard
 
@@ -18318,6 +18330,43 @@ __metadata:
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
   checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5":
+  version: 5.75.0
+  resolution: "webpack@npm:5.75.0"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.7.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.10.0
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-even-better-errors: ^2.3.1
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.4.0
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 2bcc5f3c195f375944e8af2f00bf2feea39cb9fda5f763b0d1b00077f1c51783db25c94d3fae96a07dead9fa085e6ae7474417e5ab31719c9776ea5969ceb83a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Implements validation for `process.env` values, both in the Webpack build configuration (`craco.config.ts`) and in setting the application config object (`CONFIG`) in `src/utils/constants.ts`.

### Added

- `src/utils/validateEnv` - functions to validate `process.env`

### Changed

- changes `craco.config.js` to a typescript file
- fixes caching of `.yarn/` directory in test.yml github action (reducing the run time by a minute), and removes unnecessary caching of `node_modules/` since `.yarn/` is cached (https://github.com/CMS-Enterprise/sbom-harbor/pull/33/commits/d4cf53de6ba110eb962e112c62144f2089416b88)
    - ```
      Run actions/cache@v3
      Received 88080384 of 103128876 (85.4%), 83.8 MBs/sec
      Received 103128876 of 103128876 (100.0%), 85.0 MBs/sec
      Cache Size: ~98 MB (103128876 B)
      /usr/bin/tar -xf /home/runner/work/_temp/c038a052-3705-4ca9-bb33-bf0d78088c23/cache.tzst -P -C /home/runner/work/sbom-harbor/sbom-harbor --use-compress-program unzstd
      Cache restored successfully
      Cache restored from key: yarn-cache-folder-9c5b467904efa33f6e063e0693a064feab7727bc6[19](https://github.com/CMS-Enterprise/sbom-harbor/actions/runs/4072540991/jobs/7015417555#step:6:20)f4da50b392465d00ec5eb
      ```


### Fixed

- fixes [ISPGCASP-1113](https://jiraent.cms.gov/browse/ISPGCASP-1113): _UI fails to load if env var CF_DOMAIN does not have protocol prefix_

## How to test

Locally:

⚠️ Note: `AWS_REGION` needs to be set in `.env` if it's not set through `aws-vault exec ...`

```
cd ui
yarn build
```

Once deployed:

- open chrome devtools
- set logging level to `verbose`
- confirm that the `CONFIG` variable logs to the console like so:
    - ```
      Welcome to the Harbor!
      {
        "NODE_ENV": "development",
        "AWS_REGION": "us-west-2",
        "CF_DOMAIN": "https://d23cnlbtdmow47.cloudfront.net",
        "USER_POOL_ID": "us-west-2_c64YTJbH7",
        "USER_POOL_CLIENT_ID": "bb53l6i49et782rllmmlgbubp",
        "API_URL": "https://d23cnlbtdmow47.cloudfront.net/api",
        "TEAM_API_URL": "https://d23cnlbtdmow47.cloudfront.net/api/v1/team",
        "TEAMS_API_URL": "https://d23cnlbtdmow47.cloudfront.net/api/v1/teams",
        "USER_API_URL": "https://d23cnlbtdmow47.cloudfront.net/api/v1/user",
        "USER_API_SEARCH_URL": "https://d23cnlbtdmow47.cloudfront.net/api/v1/user/search"
      }
      ```