### PR TITLE
add codeowners file to require specific reviewers for the platform crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/platform/ @DerekStrickland


### PR DESCRIPTION
## Summary

This PR adds a CODEOWNERS file to require specific reviewers for the platform crate
