### PR TITLE
chore: add codeowners for ui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-/platform/ @DerekStrickland
+/platform/ @DerekStrickland @qtpeters
+/ui/ @sbolel @qtpeters


### PR DESCRIPTION
## Summary

This PR adds codeowners 
- @sbolel and @qtpeters for the /ui/ directory
- @qtpeters in addition to @DerekStrickland to the /platform/ directory

### Changed

- `.github/CODEOWNERS`

## How to test

- n/a