### PR TITLE
chore: defining a place for project terminology

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,20 @@
 //! translating user input from the wire protocol or stdin to native types and then invoking
 //! the corresponding [Service] type found in this crate.
 
+//! ## Terminology
+//! - **Provider**: a software service that is capable of generating an SBOM given a Package
+//! - **Package**: a component for which an SBOM can be created. In the case of Harbor, this is usually a code repository like git, svn or mercurial.
+//! - **Report**: in this context, a report is a Json document. Machine readable, but with text so humans can read it as well.
+//! - **Dependency**: a library that a **Package** needs to function.
+//! - **Store**: A storage location.  This can be a:
+//!     - Document,
+//!     - File System,
+//!     - Relational, Object or Graph Database
+//!     - Cloud Storage Solution (S3, Glacier)
+//! - **Transitive Dependency**: A library that one of a given **Package**’s library needs to function.
+//!   This term is recursively accurate for any dependency of a dependency.
+//! - **Diff**: Data that represents only the changes or differences between two files.
+
 /// The [Models] module contains the schema types defined by the OpenAPI specification for this API.
 /// [Models] are data transfer objects.
 pub mod models;


### PR DESCRIPTION
## Summary

Added some Rustdoc that establishes the beginning of a glossary in Harbcore.

### Added

Rustrdoc in the file core/src/lib.rs that will serve as a glossary of terms in SBOM Harbor

## How to test

1. Position a console at the root of the SBOM Harbor repository.
2. Run `cargo doc --open`
3. Your browser should open with the documentation loaded.
4. Verify that a section named `Terminology`exists and there are some terms defined.