### PR TITLE
feat: Add EPSS enrichment source

### DIFF
--- a/ENRICHMENTS.md
+++ b/ENRICHMENTS.md
@@ -1,0 +1,101 @@
+# Implementing a New Enrichment Provider.
+
+In this tutorial, we will walk through the steps required to create a new enrichment provider.
+We will add support for enriching `Vulnerability` entries with an [EPSS Score](https://www.first.org/epss/model).
+
+## Updating the CLI
+
+Enrichments are run as CLI commands. In order to handle a new command we will need to modify the
+`cli/src/commmands/enrich/mod.rs` file in the following ways.
+
+Add new enum value to `EnrichmentProviderKind`
+
+```rust
+pub enum EnrichmentProviderKind {
+    // ...
+    /// Use the EPSS enrichment provider.
+    Epss,
+    // ...
+}
+```
+
+Add a new `match` handler to the `execute` function.
+
+```rust
+pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
+    match args.provider {
+        // ...
+        EnrichmentProviderKind::Epss => EpssProvider::execute(args).await,
+        // ...
+    }
+}
+```
+
+Update the `ValueEnum` implementation to handle the new enum variant.
+
+```rust
+impl ValueEnum for EnrichmentProviderKind {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            // ...
+            Self::Epss,
+            // ...
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            // ...
+            Self::Epss => PossibleValue::new("epss").help("Run EPSS enrichment"),
+            // ...
+        })
+    }
+}
+```
+
+Update the `FromStr` implementation to handle the new enum variant.
+
+```rust
+impl FromStr for EnrichmentProviderKind {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<EnrichmentProviderKind, Self::Err> {
+        // ...
+        match value {
+            // ...
+            "epss" => Ok(EnrichmentProviderKind::Epss),
+            // ..
+        }
+    }
+}
+```
+
+Optionally, if the new provider supports or requires args, you can define a type, and add them to
+the `EnrichArgs` struct as optional fields. See the `SnykArgs` struct as an example.
+
+## Updating Core
+
+Add new variant to `VulnerabilityProviderKind`
+
+```rust
+pub enum VulnerabilityProviderKind {
+    // ...
+    /// EPSS Score provider.
+    Epss,
+    // ...
+}
+```
+
+Update the `Display` implementation for `VulnerabilityProviderKind` to handle the new variant.
+
+```rust
+impl Display for VulnerabilityProviderKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // ...
+            VulnerabilityProviderKind::Epss => write!(f, "epss"),
+            // ...
+        }
+    }
+}
+```

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ percent-encoding = "^2.1.0"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
+uuid = "1.3.0"
 
 [dependencies.platform]
 path = "../platform"
@@ -34,4 +35,3 @@ version = "0.1.0"
 [[bin]]
 name = "harbor-cli"
 path = "src/bin/main.rs"
-

--- a/cli/src/commands/enrich/dependency_track.rs
+++ b/cli/src/commands/enrich/dependency_track.rs
@@ -1,5 +1,0 @@
-use clap::Parser;
-
-/// Args for use with the Dependency Track enrichment provider.
-#[derive(Clone, Debug, Parser)]
-pub struct DependencyTrackArgs {}

--- a/cli/src/commands/enrich/dependency_track.rs
+++ b/cli/src/commands/enrich/dependency_track.rs
@@ -1,0 +1,5 @@
+use clap::Parser;
+
+/// Args for use with the Dependency Track enrichment provider.
+#[derive(Clone, Debug, Parser)]
+pub struct DependencyTrackArgs {}

--- a/cli/src/commands/enrich/epss.rs
+++ b/cli/src/commands/enrich/epss.rs
@@ -57,8 +57,6 @@ mod tests {
     use super::*;
     use crate::Error;
     use harbcore::config::dev_context;
-    use harbcore::entities::packages::Purl;
-    use uuid::Uuid;
 
     #[async_std::test]
     #[ignore = "debug manual only"]
@@ -77,40 +75,5 @@ mod tests {
                 Err(Error::Enrich(msg))
             }
         }
-    }
-
-    #[async_std::test]
-    #[ignore = "debug manual only"]
-    async fn migrate_vulnerabilities() -> Result<(), Error> {
-        let cx = dev_context(Some("harbor")).map_err(|e| Error::Config(e.to_string()))?;
-
-        let store = Store::new(&cx)
-            .await
-            .map_err(|e| Error::Enrich(e.to_string()))?;
-
-        let purls: Vec<Purl> = match store.list().await {
-            Ok(purls) => purls,
-            Err(e) => {
-                return Err(Error::Enrich(format!("run::{}", e)));
-            }
-        };
-
-        for purl in purls.iter() {
-            if purl.vulnerabilities.is_none() {
-                continue;
-            }
-
-            let mut vulns = purl.vulnerabilities.clone().unwrap();
-            for vuln in vulns.iter_mut() {
-                vuln.id = Uuid::new_v4().to_string();
-                vuln.purl = purl.purl.clone();
-                store
-                    .insert(vuln)
-                    .await
-                    .map_err(|e| Error::Enrich(e.to_string()))?;
-            }
-        }
-
-        Ok(())
     }
 }

--- a/cli/src/commands/enrich/epss.rs
+++ b/cli/src/commands/enrich/epss.rs
@@ -1,0 +1,116 @@
+use harbcore::entities::enrichments::VulnerabilityProviderKind;
+use std::sync::Arc;
+
+use crate::commands::enrich::EnrichArgs;
+use harbcore::entities::tasks::{Task, TaskKind};
+use harbcore::services::enrichments::vulnerabilities::epss::EpssScoreTask;
+use harbcore::services::tasks::TaskProvider;
+use platform::mongodb::{Context, Store};
+
+use crate::Error;
+
+/// Strategy pattern implementation that handles EPSS Enrich commands.
+pub struct EpssProvider {}
+
+impl EpssProvider {
+    /// Factory method to create new instance of type.
+    async fn new_provider(cx: Context) -> Result<EpssScoreTask, Error> {
+        let store = Arc::new(
+            Store::new(&cx)
+                .await
+                .map_err(|e| Error::Enrich(e.to_string()))?,
+        );
+
+        let provider = EpssScoreTask::new(store);
+
+        Ok(provider)
+    }
+
+    /// Concrete implementation of the command handler. Responsible for
+    /// dispatching command to the correct logic handler based on args passed.
+    pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
+        let cx = match &args.debug {
+            false => {
+                harbcore::config::harbor_context().map_err(|e| Error::Config(e.to_string()))?
+            }
+            true => {
+                harbcore::config::dev_context(None).map_err(|e| Error::Config(e.to_string()))?
+            }
+        };
+
+        let mut task: Task = Task::new(TaskKind::Vulnerabilities(VulnerabilityProviderKind::Epss))
+            .map_err(|e| Error::Enrich(e.to_string()))?;
+
+        let provider = EpssProvider::new_provider(cx)
+            .await
+            .map_err(|e| Error::Enrich(e.to_string()))?;
+
+        provider
+            .execute(&mut task)
+            .await
+            .map_err(|e| Error::Enrich(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+    use harbcore::config::dev_context;
+    use harbcore::entities::packages::Purl;
+    use uuid::Uuid;
+
+    #[async_std::test]
+    #[ignore = "debug manual only"]
+    async fn can_execute() -> Result<(), Error> {
+        let cx = dev_context(Some("harbor")).map_err(|e| Error::Config(e.to_string()))?;
+
+        let mut task: Task = Task::new(TaskKind::Vulnerabilities(VulnerabilityProviderKind::Epss))
+            .map_err(|e| Error::Enrich(e.to_string()))?;
+
+        let provider = EpssProvider::new_provider(cx).await?;
+
+        match provider.execute(&mut task).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                Err(Error::Enrich(msg))
+            }
+        }
+    }
+
+    #[async_std::test]
+    #[ignore = "debug manual only"]
+    async fn migrate_vulnerabilities() -> Result<(), Error> {
+        let cx = dev_context(Some("harbor")).map_err(|e| Error::Config(e.to_string()))?;
+
+        let store = Store::new(&cx)
+            .await
+            .map_err(|e| Error::Enrich(e.to_string()))?;
+
+        let purls: Vec<Purl> = match store.list().await {
+            Ok(purls) => purls,
+            Err(e) => {
+                return Err(Error::Enrich(format!("run::{}", e)));
+            }
+        };
+
+        for purl in purls.iter() {
+            if purl.vulnerabilities.is_none() {
+                continue;
+            }
+
+            let mut vulns = purl.vulnerabilities.clone().unwrap();
+            for vuln in vulns.iter_mut() {
+                vuln.id = Uuid::new_v4().to_string();
+                vuln.purl = purl.purl.clone();
+                store
+                    .insert(vuln)
+                    .await
+                    .map_err(|e| Error::Enrich(e.to_string()))?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/commands/enrich/mod.rs
+++ b/cli/src/commands/enrich/mod.rs
@@ -1,4 +1,3 @@
-use crate::commands::enrich::dependency_track::DependencyTrackArgs;
 use crate::commands::enrich::epss::EpssProvider;
 use crate::commands::enrich::snyk::{SnykArgs, SnykProvider};
 use crate::Error;
@@ -6,8 +5,6 @@ use clap::builder::PossibleValue;
 use clap::{Parser, ValueEnum};
 use std::str::FromStr;
 
-/// Dependency Track enrichment command handler.
-pub mod dependency_track;
 /// EPSS enrichment command handler.
 pub mod epss;
 /// Snyk enrichment command handler.
@@ -16,8 +13,6 @@ pub mod snyk;
 /// Enumerates the supported enrichment providers.
 #[derive(Clone, Debug)]
 pub enum EnrichmentProviderKind {
-    /// Use the Dependency Track enrichment provider.
-    DependencyTrack,
     /// Use the EPSS enrichment provider.
     Epss,
     /// Use the Snyk enrichment provider.
@@ -27,9 +22,6 @@ pub enum EnrichmentProviderKind {
 /// The Enrich Command handler.
 pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
     match args.provider {
-        EnrichmentProviderKind::DependencyTrack => {
-            todo!()
-        }
         EnrichmentProviderKind::Epss => EpssProvider::execute(args).await,
         EnrichmentProviderKind::Snyk => SnykProvider::execute(args).await,
     }
@@ -37,14 +29,11 @@ pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
 
 impl ValueEnum for EnrichmentProviderKind {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::DependencyTrack, Self::Epss, Self::Snyk]
+        &[Self::Epss, Self::Snyk]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
         Some(match self {
-            Self::DependencyTrack => {
-                PossibleValue::new("dependency-track").help("Run Dependency Track enrichment")
-            }
             Self::Epss => PossibleValue::new("epss").help("Run EPSS enrichment"),
             Self::Snyk => PossibleValue::new("snyk").help("Run Snyk enrichment"),
         })
@@ -58,9 +47,6 @@ impl FromStr for EnrichmentProviderKind {
         let value = s.to_lowercase();
         let value = value.as_str();
         match value {
-            "dependencytrack" | "dependency-track" | "d" | "dt" => {
-                Ok(EnrichmentProviderKind::DependencyTrack)
-            }
             "epss" => Ok(EnrichmentProviderKind::Epss),
             "snyk" | "s" => Ok(EnrichmentProviderKind::Snyk),
             _ => Err(()),
@@ -82,8 +68,4 @@ pub struct EnrichArgs {
     /// Flattened args for use with the Snyk enrichment provider.
     #[command(flatten)]
     pub snyk_args: Option<SnykArgs>,
-
-    /// Flattened args for use with the Dependency Track enrichment provider.
-    #[command(flatten)]
-    pub dt_args: Option<DependencyTrackArgs>,
 }

--- a/cli/src/commands/enrich/mod.rs
+++ b/cli/src/commands/enrich/mod.rs
@@ -1,0 +1,89 @@
+use crate::commands::enrich::dependency_track::DependencyTrackArgs;
+use crate::commands::enrich::epss::EpssProvider;
+use crate::commands::enrich::snyk::{SnykArgs, SnykProvider};
+use crate::Error;
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
+use std::str::FromStr;
+
+/// Dependency Track enrichment command handler.
+pub mod dependency_track;
+/// EPSS enrichment command handler.
+pub mod epss;
+/// Snyk enrichment command handler.
+pub mod snyk;
+
+/// Enumerates the supported enrichment providers.
+#[derive(Clone, Debug)]
+pub enum EnrichmentProviderKind {
+    /// Use the Dependency Track enrichment provider.
+    DependencyTrack,
+    /// Use the EPSS enrichment provider.
+    Epss,
+    /// Use the Snyk enrichment provider.
+    Snyk,
+}
+
+/// The Enrich Command handler.
+pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
+    match args.provider {
+        EnrichmentProviderKind::DependencyTrack => {
+            todo!()
+        }
+        EnrichmentProviderKind::Epss => EpssProvider::execute(args).await,
+        EnrichmentProviderKind::Snyk => SnykProvider::execute(args).await,
+    }
+}
+
+impl ValueEnum for EnrichmentProviderKind {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::DependencyTrack, Self::Epss, Self::Snyk]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Self::DependencyTrack => {
+                PossibleValue::new("dependency-track").help("Run Dependency Track enrichment")
+            }
+            Self::Epss => PossibleValue::new("epss").help("Run EPSS enrichment"),
+            Self::Snyk => PossibleValue::new("snyk").help("Run Snyk enrichment"),
+        })
+    }
+}
+
+impl FromStr for EnrichmentProviderKind {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<EnrichmentProviderKind, Self::Err> {
+        let value = s.to_lowercase();
+        let value = value.as_str();
+        match value {
+            "dependencytrack" | "dependency-track" | "d" | "dt" => {
+                Ok(EnrichmentProviderKind::DependencyTrack)
+            }
+            "epss" => Ok(EnrichmentProviderKind::Epss),
+            "snyk" | "s" => Ok(EnrichmentProviderKind::Snyk),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Specifies the CLI args for the Enrich command.
+#[derive(Debug, Parser)]
+pub struct EnrichArgs {
+    /// Specifies with Enrichment Provider to invoke.
+    #[arg(short, long)]
+    pub provider: EnrichmentProviderKind,
+
+    /// Specifies to run the command against the local debug environment.
+    #[arg(long)]
+    debug: bool,
+
+    /// Flattened args for use with the Snyk enrichment provider.
+    #[command(flatten)]
+    pub snyk_args: Option<SnykArgs>,
+
+    /// Flattened args for use with the Dependency Track enrichment provider.
+    #[command(flatten)]
+    pub dt_args: Option<DependencyTrackArgs>,
+}

--- a/cli/src/commands/enrich/snyk.rs
+++ b/cli/src/commands/enrich/snyk.rs
@@ -1,8 +1,7 @@
-use std::str::FromStr;
 use std::sync::Arc;
 
-use clap::builder::PossibleValue;
-use clap::{Parser, ValueEnum};
+use crate::commands::enrich::EnrichArgs;
+use clap::Parser;
 use harbcore::entities::enrichments::VulnerabilityProviderKind;
 use harbcore::entities::tasks::{Task, TaskKind};
 use harbcore::services::enrichments::vulnerabilities::snyk::VulnerabilityScanTask;
@@ -16,80 +15,6 @@ use platform::mongodb::{Context, Store};
 
 use crate::Error;
 
-/// Specifies the CLI args for the Enrich command.
-#[derive(Debug, Parser)]
-pub struct EnrichArgs {
-    /// Specifies with Enrichment Provider to invoke.
-    #[arg(short, long)]
-    pub provider: EnrichmentProviderKind,
-
-    /// Specifies to run the command against the local debug environment.
-    #[arg(long)]
-    debug: bool,
-
-    /// Flattened args for use with the Snyk enrichment provider.
-    #[command(flatten)]
-    pub snyk_args: Option<SnykArgs>,
-
-    /// Flattened args for use with the Dependency Track enrichment provider.
-    #[command(flatten)]
-    pub dt_args: Option<DependencyTrackArgs>,
-}
-
-/// The Enrich Command handler.
-pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
-    match args.provider {
-        EnrichmentProviderKind::DependencyTrack => {
-            todo!()
-        }
-        EnrichmentProviderKind::Snyk => SnykProvider::execute(args).await,
-    }
-}
-
-/// Enumerates the supported enrichment providers.
-#[derive(Clone, Debug)]
-pub enum EnrichmentProviderKind {
-    /// Use the Dependency Track enrichment provider.
-    DependencyTrack,
-    /// Use the Snyk enrichment provider.
-    Snyk,
-}
-
-impl ValueEnum for EnrichmentProviderKind {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[Self::DependencyTrack, Self::Snyk]
-    }
-
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(match self {
-            Self::DependencyTrack => {
-                PossibleValue::new("dependency-track").help("Run Dependency Track enrichment")
-            }
-            Self::Snyk => PossibleValue::new("snyk").help("Run Snyk enrichment"),
-        })
-    }
-}
-
-impl FromStr for EnrichmentProviderKind {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<EnrichmentProviderKind, Self::Err> {
-        let value = s.to_lowercase();
-        let value = value.as_str();
-        match value {
-            "dependencytrack" | "dependency-track" | "d" | "dt" => {
-                Ok(EnrichmentProviderKind::DependencyTrack)
-            }
-            "snyk" | "s" => Ok(EnrichmentProviderKind::Snyk),
-            _ => Err(()),
-        }
-    }
-}
-
-/// Args for use with the Dependency Track enrichment provider.
-#[derive(Clone, Debug, Parser)]
-pub struct DependencyTrackArgs {}
-
 /// Args for use with the Snyk enrichment provider.
 #[derive(Clone, Debug, Parser)]
 pub struct SnykArgs {
@@ -102,7 +27,7 @@ pub struct SnykArgs {
 }
 
 /// Strategy pattern implementation that handles Snyk Enrich commands.
-struct SnykProvider {}
+pub struct SnykProvider {}
 
 impl SnykProvider {
     /// Factory method to create new instance of type.
@@ -130,7 +55,7 @@ impl SnykProvider {
 
     /// Concrete implementation of the command handler. Responsible for
     /// dispatching command to the correct logic handler based on args passed.
-    async fn execute(args: &EnrichArgs) -> Result<(), Error> {
+    pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
         let storage: Box<dyn StorageProvider>;
 
         let cx = match &args.debug {
@@ -159,9 +84,9 @@ impl SnykProvider {
                 provider
                     .execute(&mut task)
                     .await
-                    .map_err(|e| Error::Sbom(e.to_string()))
+                    .map_err(|e| Error::Enrich(e.to_string()))
             }
-            Some(_a) => Err(Error::Sbom(
+            Some(_a) => Err(Error::Enrich(
                 "individual project not yet implemented".to_string(),
             )),
         }
@@ -191,7 +116,7 @@ mod tests {
             Ok(_) => Ok(()),
             Err(e) => {
                 let msg = e.to_string();
-                Err(Error::Sbom(msg))
+                Err(Error::Enrich(msg))
             }
         }
     }

--- a/core/src/entities/enrichments/vulnerabilities.rs
+++ b/core/src/entities/enrichments/vulnerabilities.rs
@@ -79,8 +79,6 @@ impl Vulnerability {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum VulnerabilityProviderKind {
-    /// Dependency Track provider.
-    DependencyTrack,
     /// EPSS Score provider.
     Epss,
     /// Ion Channel provider.
@@ -94,7 +92,6 @@ pub enum VulnerabilityProviderKind {
 impl Display for VulnerabilityProviderKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            VulnerabilityProviderKind::DependencyTrack => write!(f, "dependency-track"),
             VulnerabilityProviderKind::Epss => write!(f, "epss"),
             VulnerabilityProviderKind::IonChannel => write!(f, "ion-channel"),
             VulnerabilityProviderKind::Snyk => write!(f, "snyk"),

--- a/core/src/entities/enrichments/vulnerabilities.rs
+++ b/core/src/entities/enrichments/vulnerabilities.rs
@@ -16,7 +16,7 @@ pub struct Vulnerability {
     /// Unique identifier for instance.
     pub id: String,
 
-    /// Package URL that the [Vulnerability] pertains to.
+    /// The Package URL that the [Vulnerability] pertains to.
     pub purl: String,
 
     /// Indicates which enrichment provider reported the vulnerability.
@@ -30,6 +30,9 @@ pub struct Vulnerability {
 
     /// The CVE description of the [Vulnerability].
     pub description: Option<String>,
+
+    /// The EPSS Score for the CVE ID.
+    pub epss_score: Option<f32>,
 
     /// Optional CVSS Detail from the enrichment provider.
     pub cvss: Option<Summary>,
@@ -70,14 +73,16 @@ impl Vulnerability {
     }
 }
 
-/// Discriminator used to indicate what enrichment provider identified a [Vulnerability]. Implementers
-/// that want to develop their own enrichment sources and don't intend to contribute them back upstream can
-/// use the Custom variant without having to hard fork.
+/// Discriminator used to indicate what enrichment provider identified or scored a [Vulnerability].
+/// Implementers that want to develop their own enrichment sources and don't intend to contribute '
+/// them back upstream can use the Custom variant without having to hard fork.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum VulnerabilityProviderKind {
     /// Dependency Track provider.
     DependencyTrack,
+    /// EPSS Score provider.
+    Epss,
     /// Ion Channel provider.
     IonChannel,
     /// Snyk provider.
@@ -90,6 +95,7 @@ impl Display for VulnerabilityProviderKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             VulnerabilityProviderKind::DependencyTrack => write!(f, "dependency-track"),
+            VulnerabilityProviderKind::Epss => write!(f, "epss"),
             VulnerabilityProviderKind::IonChannel => write!(f, "ion-channel"),
             VulnerabilityProviderKind::Snyk => write!(f, "snyk"),
             VulnerabilityProviderKind::Custom(name) => write!(f, "custom-{}", name),
@@ -158,6 +164,7 @@ mod tests {
                         severity: None,
                         cve: Some("CVE-2023-0842".to_string()),
                         description: None,
+                        epss_score: None,
                         cvss: None,
                         cwes: None,
                         remediation: None,
@@ -184,6 +191,7 @@ mod tests {
                         severity: None,
                         cve: Some("CVE-2023-0842".to_string()),
                         description: None,
+                        epss_score: None,
                         cvss: None,
                         cwes: None,
                         remediation: None,
@@ -214,6 +222,7 @@ mod tests {
                         severity: None,
                         cve: Some("CVE-2023-0842".to_string()),
                         description: None,
+                        epss_score: None,
                         cvss: None,
                         cwes: None,
                         remediation: None,
@@ -240,6 +249,7 @@ mod tests {
                         severity: None,
                         cve: Some("CVE-2023-0842".to_string()),
                         description: None,
+                        epss_score: None,
                         cvss: None,
                         cwes: None,
                         remediation: None,

--- a/core/src/entities/packages/package.rs
+++ b/core/src/entities/packages/package.rs
@@ -111,7 +111,7 @@ impl Package {
 
         let mut package = Package {
             id: "".to_string(),
-            kind: PackageKind::Direct,
+            kind: PackageKind::Primary,
             package_manager,
             version,
             cpe: bom.cpe(),
@@ -226,7 +226,7 @@ impl Package {
 #[serde(rename_all = "camelCase")]
 pub enum PackageKind {
     /// Indicates a [Package] is being directly monitored.
-    Direct,
+    Primary,
     /// Indicates a [Package] is a dependency of a [Package] being directly monitored.
     Dependency,
 }
@@ -234,7 +234,7 @@ pub enum PackageKind {
 impl ToString for PackageKind {
     fn to_string(&self) -> String {
         match self {
-            PackageKind::Direct => "direct".to_string(),
+            PackageKind::Primary => "primary".to_string(),
             PackageKind::Dependency => "dependency".to_string(),
         }
     }

--- a/core/src/services/enrichments/vulnerabilities/epss/client.rs
+++ b/core/src/services/enrichments/vulnerabilities/epss/client.rs
@@ -1,0 +1,88 @@
+use crate::Error;
+use platform::hyper::ContentType;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub(in crate::services::enrichments::vulnerabilities::epss) struct Client {
+    inner: platform::hyper::Client,
+}
+
+impl Client {
+    pub fn new() -> Client {
+        let inner = platform::hyper::Client::new();
+
+        Client { inner }
+    }
+
+    pub async fn score(&self, cve: String) -> Result<f32, Error> {
+        let uri = format!("https://api.first.org/data/v1/epss?cve={}", cve);
+
+        let response: Option<EpssResponse> = self
+            .inner
+            .get(uri.as_str(), ContentType::Json, "", None::<EpssResponse>)
+            .await?;
+
+        let response = match response {
+            None => {
+                return Err(Error::Vulnerability("epss_score_none".to_string()));
+            }
+            Some(response) => response,
+        };
+
+        if response.status_code != 200 {
+            return Err(Error::Vulnerability(format!(
+                "epss_status_code::{}",
+                response.status_code
+            )));
+        }
+
+        let score = match response.data.iter().find(|score| score.cve == cve) {
+            None => {
+                return Err(Error::Vulnerability("epss_score_not_found".to_string()));
+            }
+            Some(score) => &score.epss,
+        };
+
+        score
+            .parse::<f32>()
+            .map_err(|e| Error::InvalidFormat(format!("epss_score::{}", e)))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct EpssResponse {
+    #[serde(rename = "status-code")]
+    status_code: u8,
+    data: Vec<EpssScore>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct EpssScore {
+    cve: String,
+    epss: String,
+    percentile: String,
+    date: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+
+    #[async_std::test]
+    async fn can_get_epss_score() -> Result<(), Error> {
+        let client = Client::new();
+
+        let score = client
+            .score("CVE-2021-40438".to_string())
+            .await
+            .map_err(|e| Error::Vulnerability(e.to_string()))?;
+
+<<<<<<< Updated upstream
+        assert_ne!(0.0_f32, score);
+=======
+        assert_ne!(0.0 as f32, score);
+>>>>>>> Stashed changes
+        Ok(())
+    }
+}

--- a/core/src/services/enrichments/vulnerabilities/epss/client.rs
+++ b/core/src/services/enrichments/vulnerabilities/epss/client.rs
@@ -78,11 +78,8 @@ mod tests {
             .await
             .map_err(|e| Error::Vulnerability(e.to_string()))?;
 
-<<<<<<< Updated upstream
-        assert_ne!(0.0_f32, score);
-=======
         assert_ne!(0.0 as f32, score);
->>>>>>> Stashed changes
+
         Ok(())
     }
 }

--- a/core/src/services/enrichments/vulnerabilities/epss/mod.rs
+++ b/core/src/services/enrichments/vulnerabilities/epss/mod.rs
@@ -1,0 +1,105 @@
+mod client;
+
+use crate::entities::enrichments::Vulnerability;
+use crate::entities::tasks::Task;
+use crate::services::tasks::TaskProvider;
+use crate::Error;
+use async_trait::async_trait;
+use client::Client;
+use platform::mongodb::{Service, Store};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Analyzes the full set of [Vulnerability] entries and retrieves an EPSS Score by CVE ID.
+#[derive(Debug)]
+pub struct EpssScoreTask {
+    store: Arc<Store>,
+    client: Client,
+}
+
+#[async_trait]
+impl TaskProvider for EpssScoreTask {
+    async fn run(&self, task: &mut Task) -> Result<HashMap<String, String>, Error> {
+        println!("==> fetching vulnerabilities");
+
+        let mut targets: Vec<Vulnerability> = match self.list().await {
+            Ok(vulnerabilities) => vulnerabilities,
+            Err(e) => {
+                return Err(Error::Vulnerability(format!("run::{}", e)));
+            }
+        };
+
+        if targets.is_empty() {
+            return Err(Error::Snyk("run::no_vulnerabilities".to_string()));
+        }
+
+        let total = targets.len();
+        println!("==> processing {} vulnerabilities...", total);
+        task.count = targets.len() as u64;
+
+        let mut iteration = 0;
+        let mut errors = HashMap::new();
+
+        for vulnerability in targets.iter_mut() {
+            iteration += 1;
+            println!("==> processing iteration {} of {}", iteration, total);
+
+            match self.process_target(vulnerability).await {
+                Ok(_) => {
+                    println!("==> iteration {} succeeded", iteration);
+                }
+                Err(e) => {
+                    // Don't fail on a single error.
+                    println!("==> iteration {} failed with error: {}", iteration, e);
+                    errors.insert(vulnerability.purl.clone(), e.to_string());
+                }
+            }
+        }
+
+        Ok(errors)
+    }
+}
+
+impl Service<Vulnerability> for EpssScoreTask {
+    fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+}
+
+impl Service<Task> for EpssScoreTask {
+    fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+}
+
+impl EpssScoreTask {
+    /// Factory method to create new instance of type.
+    pub fn new(store: Arc<Store>) -> EpssScoreTask {
+        let client = Client::new();
+
+        EpssScoreTask { store, client }
+    }
+
+    pub(in crate::services::enrichments::vulnerabilities::epss) async fn process_target(
+        &self,
+        vulnerability: &mut Vulnerability,
+    ) -> Result<(), Error> {
+        let cve = match &vulnerability.cve {
+            None => {
+                return Err(Error::Vulnerability("cve_none".to_string()));
+            }
+            Some(cve) => cve,
+        };
+
+        vulnerability.epss_score = match self.client.score(cve.clone()).await {
+            Ok(score) => Some(score),
+            Err(e) => {
+                return Err(Error::Vulnerability(e.to_string()));
+            }
+        };
+
+        self.update(vulnerability)
+            .await
+            .map_err(|e| Error::Vulnerability(e.to_string()))
+    }
+}

--- a/core/src/services/enrichments/vulnerabilities/mod.rs
+++ b/core/src/services/enrichments/vulnerabilities/mod.rs
@@ -3,6 +3,9 @@ mod service;
 /// Supports generating [Vulnerability] instances from the Snyk API.
 pub mod snyk;
 
+/// Supports adding an EPSS Score to a [Vulnerability].
+pub mod epss;
+
 pub use service::*;
 use std::collections::HashMap;
 

--- a/core/src/services/snyk/adapters.rs
+++ b/core/src/services/snyk/adapters.rs
@@ -161,6 +161,7 @@ impl IssueSnyk {
             provider: VulnerabilityProviderKind::Snyk,
             severity,
             cve: self.cve(),
+            epss_score: None,
             description: self.description(),
             cvss: self.cvss(),
             cwes: self.cwes(),


### PR DESCRIPTION
## Summary

This PR adds an EPSS Enrichment provider.

### Added

EPSS Enrichment provider

### Changed

- Renamed `PackageKind::Direct` to `PackageKind::Primary` based on industry standard.
- I split the `cli` commands into separate modules/files since the single files were getting large

## How to test

- `cargo build`
- Start the local dev environment
- `./target/debug/harbor-cli sbom --debug -p snyk`
- `./target/debug/harbor-cli enrich --debug -p snyk`
- `./target/debug/harbor-cli enrich --debug -p epss`
- check that `epssScore` is populated in the `Vulnerability` collection
- if not, verify that the `cve` is null or that the api result for that CVE is an empty array, for example this one has a CVE but EPSS API returns no data https://api.first.org/data/v1/epss?cve=CVE-2023-26115)