### PR TITLE
fix(sdl_report_analytic): added all the data from earlier stages into the Stage 6 $group stage

### DIFF
--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -114,6 +114,24 @@ fn report_analytic_stage_6() -> Stage {
     Stage::new(json!({
         "$group": {
           "_id": "$_id",
+          "name": {
+            "$first": "$name"
+          },
+          "packageManager": {
+            "$first": "$packageManager"
+          },
+          "purl": {
+            "$first": "$purl"
+          },
+          "provider": {
+            "$first": "$provider"
+          },
+          "version": {
+            "$first": "$version"
+          },
+          "timestamp": {
+            "$first": "$timestamp"
+          },
           "report": {
             "$push": "$report",
           },

--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -204,26 +204,7 @@ fn report_analytic_stage_11() -> Stage {
                 "$first": "$version"
             },
             "created": {
-                "$first": {
-                    "$dateFromString": {
-                        "dateString": {
-                            "$concat": [
-                                {
-                                    "$concat": [
-                                        {
-                                            "$multiply": [
-                                                "$timestamp",
-                                                1000
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                "Z"
-                            ]
-                        }
-                    }
-                }
+                "$first": "$timestamp"
             },
             "report": {
                 "$push": {


### PR DESCRIPTION
## Summary

The SDL report data in S3 has several missing values (null).  To get the data into those values, the $group stage in Stage 6 of the Aggregation Pipeline has been augmented to pass the values along form earlier stages. 

### Changed

Stage 6 of the Aggregation Pipeline to move data to the next stage

### Fixed

The problem of having no SBOM data in the SDL report

## How to test

1. Run Snyk SBOM provider
2. Run Snyk Vulnerability Provider
3. Run SDL Report Analytic
4. Verify that the data makes it into the SDL report
