### PR TITLE
feat: add epssScore to sbom-detail analytic

### DIFF
--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -173,6 +173,7 @@ fn report_analytic_stage_10() -> Stage {
                    "severity":"$$this.severity",
                    "cve":"$$this.cve",
                    "description":"$$this.description",
+                   "epssScore":"$$this.epssScore",
                    "cvss":"$$this.cvss",
                    "cwes":"$$this.cwes",
                    "remediation":"$$this.remediation"

--- a/sdk/core/src/tasks/enrichments/vulnerabilities/epss/client.rs
+++ b/sdk/core/src/tasks/enrichments/vulnerabilities/epss/client.rs
@@ -78,7 +78,7 @@ mod tests {
             .await
             .map_err(|e| Error::Vulnerability(e.to_string()))?;
 
-        assert_ne!(0.0 as f32, score);
+        assert_ne!(0.0_f32, score);
 
         Ok(())
     }


### PR DESCRIPTION


## Summary

Adds EPSS Score results from the EPSS Provider to the SBOM Detail report output

### Added

New report field.

## How to test

- `cargo build`
- Start devenv
- Run `harbor ingest -p snyk --debug`
- Run `harbor enrich -p snyk --debug`
- Run `harbor enrich -p epss --debug`
- Run `harbor analyze sbom-detail --debug` 
- Check SBOM detail output and verify `epssScore` field shows up in report.

Note to reviewers: Sometimes EPSS returns no result and those values will be null. This is to be expected.