### PR TITLE
fix: fix gh-pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - docs-fix-deploy
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - docs-init-book
 
 jobs:
   deploy:
@@ -33,7 +32,7 @@ jobs:
           # Delete the ref to avoid keeping history.
           git update-ref -d refs/heads/gh-pages
           rm -rf *
-          mv ../docs/* .
+          mv ../book/* .
           git add .
           git commit -m "Deploy $GITHUB_SHA to gh-pages"
           git push --force --set-upstream origin gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - docs-fix-deploy
 
 jobs:
   deploy:


### PR DESCRIPTION

## Summary

Fixes a bug in the mdbook deploy script that was introduced when renaming the docs folder. 

### Fixed

The build output directory is still `book` even though the parent directory name is docs. That should never have been changed.

## How to test

Merge this PR to `main` and make sure the deploy works.