### PR TITLE
refactor: created a reusable ingest method on the SbomService.

### DIFF
--- a/cli/src/commands/ingest/snyk.rs
+++ b/cli/src/commands/ingest/snyk.rs
@@ -53,7 +53,11 @@ pub(crate) async fn execute(args: &IngestArgs) -> Result<(), Error> {
         store.clone(),
         SnykService::new(token),
         PackageService::new(store.clone()),
-        SbomService::new(store, storage),
+        SbomService::new(
+            store.clone(),
+            storage,
+            Some(PackageService::new(store.clone())),
+        ),
     )
     .map_err(|e| Error::Sbom(e.to_string()))?;
 

--- a/sdk/core/src/services/sboms/service.rs
+++ b/sdk/core/src/services/sboms/service.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 
 use platform::persistence::mongodb::{Service, Store};
 
-use crate::entities::sboms::Sbom;
+use crate::entities::sboms::{Author, CdxFormat, Sbom, SbomProviderKind};
+use crate::entities::tasks::Task;
 use crate::entities::xrefs::Xref;
+use crate::services::packages::PackageService;
 use crate::services::sboms::StorageProvider;
 use crate::services::xrefs::XrefService;
 use crate::Error;
@@ -35,6 +37,7 @@ impl XrefService<Sbom> for SbomService {}
 pub struct SbomService {
     store: Arc<Store>,
     storage: Box<dyn StorageProvider>,
+    packages: Option<PackageService>,
 }
 
 impl Service<Sbom> for SbomService {
@@ -45,8 +48,149 @@ impl Service<Sbom> for SbomService {
 
 impl SbomService {
     /// Factory method for creating new instance of type.
-    pub fn new(store: Arc<Store>, storage: Box<dyn StorageProvider>) -> Self {
-        Self { store, storage }
+    pub fn new(
+        store: Arc<Store>,
+        storage: Box<dyn StorageProvider>,
+        packages: Option<PackageService>,
+    ) -> Self {
+        Self {
+            store,
+            storage,
+            packages,
+        }
+    }
+
+    /// Processes a raw SBOM and loads it into the Harbor data and file stores.
+    pub async fn ingest(
+        &self,
+        raw: &str,
+        package_manager: Option<String>,
+        provider: SbomProviderKind,
+        xref: Xref,
+        task: &Task,
+    ) -> Result<Sbom, Error> {
+        // Load the raw SBOM into the Harbor model.
+        let mut sbom = match Sbom::from_raw_cdx(
+            raw,
+            CdxFormat::Json,
+            Author::Harbor(provider),
+            &package_manager,
+            xref.clone(),
+            task,
+        ) {
+            Ok(sbom) => sbom,
+            Err(e) => {
+                let msg = format!("ingest::from_raw_cdx::{}", e);
+                println!("{}", msg);
+                return Err(Error::Sbom(msg));
+            }
+        };
+
+        // Determine how many times this Sbom has been synced.
+        match self.set_instance_by_purl(&mut sbom).await {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = format!("ingest::set_instance_by_purl::{}", e);
+                println!("{}", msg);
+                return Err(Error::Sbom(msg));
+            }
+        }
+
+        // Write the sbom to the storage provider.
+        match self
+            .write_to_storage(raw.as_bytes().to_vec(), &mut sbom, Some(xref.clone()))
+            .await
+        {
+            Ok(()) => {
+                // TODO: Emit Metric.
+                println!("ingest::write_to_storage::success");
+            }
+            Err(e) => {
+                // TODO: Emit Metric.
+                let msg = format!("ingest::write_to_storage::{}", e);
+                println!("{}", msg);
+                return Err(Error::Sbom(msg));
+            }
+        };
+
+        // Ensure the timestamp is set if successful.
+        sbom.timestamp = platform::time::timestamp()?;
+
+        // Commit the Sbom.
+        self.commit(&mut sbom, xref).await?;
+
+        Ok(sbom)
+    }
+
+    /// [Transaction script](https://martinfowler.com/eaaCatalog/transactionScript.html) for saving
+    /// Sbom results to data store. If change_set None, indicates Sbom has errors and dependent
+    /// entities should not be committed.
+    async fn commit(&self, sbom: &mut Sbom, xref: Xref) -> Result<(), Error> {
+        let mut errs = HashMap::<String, String>::new();
+
+        // Should always insert Sbom. It should never be a duplicate, but a new instance from task.
+        match self.insert(sbom).await {
+            Ok(_) => {}
+            Err(e) => {
+                return Err(Error::Sbom(e.to_string()));
+            }
+        }
+
+        let mut package = match sbom.package.clone() {
+            Some(package) => package,
+            None => {
+                return Err(Error::Sbom("sbom_package_none".to_string()));
+            }
+        };
+
+        let packages = match &self.packages {
+            None => {
+                return Err(Error::Config("package_service_none".to_string()));
+            }
+            Some(packages) => packages,
+        };
+
+        // Upsert the Package for the SBOM target
+        match packages
+            .upsert_package_by_purl(&mut package, Some(&xref))
+            .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                errs.insert("package".to_string(), e.to_string());
+            }
+        }
+
+        if !errs.is_empty() {
+            let errs = match serde_json::to_string(&errs) {
+                Ok(errs) => errs,
+                Err(e) => format!("error serializing errs {}", e),
+            };
+            return Err(Error::Sbom(errs));
+        }
+
+        // Upsert packages for each dependency.
+        for dependency in package.dependencies.iter_mut() {
+            match packages
+                .upsert_package_by_purl(dependency, Some(&xref))
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => {
+                    errs.insert("package".to_string(), e.to_string());
+                }
+            }
+        }
+
+        if !errs.is_empty() {
+            let errs = match serde_json::to_string(&errs) {
+                Ok(errs) => errs,
+                Err(e) => format!("error serializing errs {}", e),
+            };
+            return Err(Error::Sbom(errs));
+        }
+
+        Ok(())
     }
 
     /// Stores the SBOM to the configured persistence provider using the Purl as the unique

--- a/sdk/core/src/tasks/sboms/snyk/mod.rs
+++ b/sdk/core/src/tasks/sboms/snyk/mod.rs
@@ -41,10 +41,11 @@ mod tests {
             SnykService::new(token),
             PackageService::new(store.clone()),
             SbomService::new(
-                store,
+                store.clone(),
                 Box::new(FileSystemStorageProvider::new(
                     "/tmp/harbor/sboms".to_string(),
                 )),
+                Some(PackageService::new(store.clone())),
             ),
         )?;
 

--- a/sdk/core/src/tasks/sboms/snyk/sync.rs
+++ b/sdk/core/src/tasks/sboms/snyk/sync.rs
@@ -1,4 +1,4 @@
-use crate::entities::sboms::{Author, CdxFormat, Sbom, SbomProviderKind};
+use crate::entities::sboms::SbomProviderKind;
 use crate::services::snyk::adapters::Project;
 use crate::services::snyk::ProjectStatus;
 use crate::services::snyk::{SnykService, SUPPORTED_SBOM_PROJECT_TYPES};
@@ -130,63 +130,16 @@ impl SyncTask {
             }
         };
 
-        // Load the raw Snyk result into the Harbor model.
-        let mut sbom = match Sbom::from_raw_cdx(
-            raw.as_str(),
-            CdxFormat::Json,
-            Author::Harbor(SbomProviderKind::Snyk),
-            &package_manager,
-            Xref::from(snyk_ref.clone()),
-            task,
-        ) {
-            Ok(sbom) => sbom,
-            Err(e) => {
-                let msg = format!("process_target::from_raw_cdx::{}", e);
-                debug!("{}", msg);
-                return Err(Error::Sbom(msg));
-            }
-        };
-
-        // Determine how many times this Sbom has been synced.
-        match self.sboms.set_instance_by_purl(&mut sbom).await {
-            Ok(_) => {}
-            Err(e) => {
-                let msg = format!("process_target::from_raw_cdx::{}", e);
-                debug!("{}", msg);
-                return Err(Error::Sbom(msg));
-            }
-        }
-
-        // Write the sbom to the storage provider.
-        match self
-            .sboms
-            .write_to_storage(
-                raw.as_bytes().to_vec(),
-                &mut sbom,
-                Some(Xref::from(snyk_ref.clone())),
+        // Load the raw Snyk result into the Harbor model and save to the data store.
+        self.sboms
+            .ingest(
+                raw.as_str(),
+                package_manager,
+                SbomProviderKind::Snyk,
+                Xref::from(snyk_ref),
+                task,
             )
-            .await
-        {
-            Ok(()) => {
-                // TODO: Emit Metric.
-                debug!("process_target::write_to_storage::success");
-            }
-            Err(e) => {
-                // TODO: Emit Metric.
-                let msg = format!("process_target::write_to_storage::{}", e);
-                debug!("{}", msg);
-                return Err(Error::Sbom(msg));
-            }
-        };
-
-        // Ensure the timestamp is set if successful.
-        sbom.timestamp = platform::time::timestamp()?;
-
-        // Ensure the display timestamp is set if successful.
-        sbom.created = platform::time::iso8601_timestamp()?;
-
-        // Commit the Sbom.
-        self.commit_target(&mut sbom, Xref::from(snyk_ref)).await?;
+            .await?;
 
         Ok(())
     }
@@ -196,70 +149,6 @@ impl SyncTask {
         let msg = "handle_inactive::inactive";
         debug!("{}::{}", msg, project.project_name);
         // TODO: Track inactive?
-        Ok(())
-    }
-
-    /// [Transaction script](https://martinfowler.com/eaaCatalog/transactionScript.html) for saving
-    /// Sbom results to data store. If change_set None, indicates Sbom has errors and dependent
-    /// entities should not be committed.
-    pub(crate) async fn commit_target(&self, sbom: &mut Sbom, xref: Xref) -> Result<(), Error> {
-        let mut errs = HashMap::<String, String>::new();
-
-        // Should always insert Sbom. It should never be a duplicate, but a new instance from task.
-        match self.sboms.insert(sbom).await {
-            Ok(_) => {}
-            Err(e) => {
-                return Err(Error::Sbom(e.to_string()));
-            }
-        }
-
-        let mut package = match sbom.package.clone() {
-            Some(package) => package,
-            None => {
-                return Err(Error::Sbom("sbom_package_none".to_string()));
-            }
-        };
-
-        match self
-            .packages
-            .upsert_package_by_purl(&mut package, Some(&xref))
-            .await
-        {
-            Ok(_) => {}
-            Err(e) => {
-                errs.insert("package".to_string(), e.to_string());
-            }
-        }
-
-        if !errs.is_empty() {
-            let errs = match serde_json::to_string(&errs) {
-                Ok(errs) => errs,
-                Err(e) => format!("error serializing errs {}", e),
-            };
-            return Err(Error::Sbom(errs));
-        }
-
-        for dependency in package.dependencies.iter_mut() {
-            match self
-                .packages
-                .upsert_package_by_purl(dependency, Some(&xref))
-                .await
-            {
-                Ok(_) => {}
-                Err(e) => {
-                    errs.insert("package".to_string(), e.to_string());
-                }
-            }
-        }
-
-        if !errs.is_empty() {
-            let errs = match serde_json::to_string(&errs) {
-                Ok(errs) => errs,
-                Err(e) => format!("error serializing errs {}", e),
-            };
-            return Err(Error::Sbom(errs));
-        }
-
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This PR extracts the SBOM ingestion logic from the Snyk specific `SyncTask` and moves it to the `SbomService`.

### Added

Added an optional `PackageService` field to the `SbomService`. 

### Changed

See summary.

## How to test

- Pull branch
- cargo build
- Start the devenv per the readme
- Run the tests
