### PR TITLE
fix: api now listens on all addresses

### DIFF
--- a/api/src/bin/main.rs
+++ b/api/src/bin/main.rs
@@ -101,7 +101,7 @@ async fn main() {
         .layer(cors)
         .layer(tracer);
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+    let addr = SocketAddr::from(([0, 0, 0, 0], 5000));
     info!("harbor listening on {}", addr);
 
     axum::Server::bind(&addr)

--- a/sdk/core/src/tasks/sboms/snyk/mod.rs
+++ b/sdk/core/src/tasks/sboms/snyk/mod.rs
@@ -45,7 +45,7 @@ mod tests {
                 Box::new(FileSystemStorageProvider::new(
                     "/tmp/harbor/sboms".to_string(),
                 )),
-                Some(PackageService::new(store.clone())),
+                Some(PackageService::new(store)),
             ),
         )?;
 


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/ISPGCASP/) to the PR title like this `[ISPGCASP-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

Fixed an issue where the api only listened on the loopback. It now listens on all addresses.

### Added

none

### Changed

Listen on 0.0.0.0 instead of 127.0.0.1

### Deprecated

none

### Removed

none

### Fixed

Listen on 0.0.0.0 instead of 127.0.0.1

## How to test

