### PR TITLE
feat(private_repos_and_forks): now the provider can find public, private and forked repos

### DIFF
--- a/sdk/core/src/services/github/client/mod.rs
+++ b/sdk/core/src/services/github/client/mod.rs
@@ -52,18 +52,16 @@ impl Client {
         match response {
             Ok(option) => match option {
                 Some(value) => {
-
                     let num_public_repos = value.public_repo_count;
                     let num_private_repos = value.private_repo_count;
 
                     println!(
                         "Found {} public repos and {} private repos",
-                        num_public_repos,
-                        num_private_repos
+                        num_public_repos, num_private_repos
                     );
 
                     Ok(Some(num_public_repos + num_private_repos))
-                },
+                }
                 None => Err(Error::GitHubErrorResponse(
                     "==> Get request from GitHub had an empty response".to_string(),
                 )),
@@ -163,7 +161,7 @@ impl Client {
                 Some(value) => {
                     println!("==> response is ok, {} repos returned", value.len());
                     Ok(value)
-                },
+                }
                 None => Err(Error::GitHubErrorResponse(
                     "Get request from GitHub had an empty response".to_string(),
                 )),
@@ -198,7 +196,7 @@ pub struct Org {
     private_repo_count: u32,
 }
 
-fn default_num_repos() ->u32 {
+fn default_num_repos() -> u32 {
     0
 }
 
@@ -259,9 +257,9 @@ impl Repo {
 
 #[cfg(test)]
 mod test {
-    use platform::config::from_env;
     use crate::services::github::client::Client;
     use crate::services::github::error::Error;
+    use platform::config::from_env;
 
     /// This test must be run with a GitHub PAT that has the correct permissions
     /// Fine grained PATs do not work, the token must be a classic PAT with these perms:
@@ -271,8 +269,7 @@ mod test {
     /// This is a good place to test a PAT from GItHub
     #[tokio::test]
     #[ignore = "debug manual only"]
-    async fn test_get_page_repos() -> Result<(), Error>{
-
+    async fn test_get_page_repos() -> Result<(), Error> {
         // https://github.com/orgs/harbor-test-org/repositories
         let total_repos_in_harbor_test_org = 11;
 
@@ -285,19 +282,16 @@ mod test {
         let num_per_page = 100 as u32;
 
         let client = Client::new(pat);
-        let repo_page = client.get_page_of_repos(
-            &String::from("harbor-test-org"),
-            page_num,
-            &num_per_page
-        ).await;
+        let repo_page = client
+            .get_page_of_repos(&String::from("harbor-test-org"), page_num, &num_per_page)
+            .await;
 
         match repo_page {
             Ok(repos) => {
                 assert_eq!(repos.len(), total_repos_in_harbor_test_org);
                 Ok(())
-            },
-            Err(err) => Err(err)
+            }
+            Err(err) => Err(err),
         }
     }
 }
-

--- a/sdk/core/src/services/github/service.rs
+++ b/sdk/core/src/services/github/service.rs
@@ -34,8 +34,6 @@ impl GitHubService {
             }
         };
 
-        println!("Looking at pages: {:#?}", pages);
-
         let mut repo_vec: Vec<Repo> = Vec::new();
         for (page, per_page) in pages.iter_mut().enumerate() {
             let mut gh_org_rsp = self
@@ -43,7 +41,15 @@ impl GitHubService {
                 .get_page_of_repos(&self.org, page + 1, per_page)
                 .await?;
 
+            println!("==> processing page {}. There are {} repos", page, per_page);
+
             for repo in gh_org_rsp.iter_mut() {
+
+                println!(
+                    "==> getting last commit for repo : {:#?}",
+                    repo.full_name.clone().unwrap()
+                );
+
                 let result = self.client.get_last_commit(repo).await;
                 let repo_name = repo.full_name.clone().unwrap();
 

--- a/sdk/core/src/services/github/service.rs
+++ b/sdk/core/src/services/github/service.rs
@@ -44,7 +44,6 @@ impl GitHubService {
             println!("==> processing page {}. There are {} repos", page, per_page);
 
             for repo in gh_org_rsp.iter_mut() {
-
                 println!(
                     "==> getting last commit for repo : {:#?}",
                     repo.full_name.clone().unwrap()

--- a/sdk/core/src/services/syft/mod.rs
+++ b/sdk/core/src/services/syft/mod.rs
@@ -173,8 +173,11 @@ impl Service {
             }
         }
 
-        if let Some(path) = orig_dir.clone() {
-            println!("==> about to change directories back to: {:#?}\n", path.to_str().unwrap());
+        if let Some(path) = orig_dir {
+            println!(
+                "==> about to change directories back to: {:#?}\n",
+                path.to_str().unwrap()
+            );
             env::set_current_dir(path).map_err(|err| {
                 Error::SyftError(format!(
                     "Unable to change directories back to original location: {}",

--- a/sdk/core/src/services/syft/mod.rs
+++ b/sdk/core/src/services/syft/mod.rs
@@ -174,7 +174,7 @@ impl Service {
         }
 
         if let Some(path) = orig_dir.clone() {
-            println!("==> about to change directories back to: {:#?}", orig_dir.clone());
+            println!("==> about to change directories back to: {:#?}\n", path.to_str().unwrap());
             env::set_current_dir(path).map_err(|err| {
                 Error::SyftError(format!(
                     "Unable to change directories back to original location: {}",


### PR DESCRIPTION
## Summary

GitHub provider can now find Forks and Private Repos

### Changed

- Changed the type of repos we are looking for in the request.  Instead of `sources` now, it's `all`
  - https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-organization-repositories
- Not a code change, but the type of token that must be generated to find Private Repos was figured out.
  - Instead of a finely grained token, it must be a Classic GitHub PAT with these permissions:                                                                
    - repo (all)                                                                
    - admin:public_key                                                          
    - admin:org, only read:org

## How to test

Go to GitHub and generate a Classic token with the above permissions. Load that token into your environment:

export GITHUB_PAT=ghp_blahblahblahfakepat

Then, in the IDE, run:
- services::github::client::test::test_get_page_repos

Make sure the token is in the environment or only 10 repos will be found instead of 11.  The 11th repo is private.