### PR TITLE
feat(purl-generation): Syft Service now creates a well formed, sensible purl for the Package

### DIFF
--- a/api/src/controllers/product.rs
+++ b/api/src/controllers/product.rs
@@ -145,8 +145,6 @@ pub async fn put(
         return Err(Error::InvalidParameters("id mismatch".to_string()));
     }
 
-    let product = product;
-
     service
         .update(&product)
         .await

--- a/api/src/controllers/team.rs
+++ b/api/src/controllers/team.rs
@@ -120,8 +120,6 @@ pub async fn put(
         return Err(Error::InvalidParameters("id mismatch".to_string()));
     }
 
-    let team = team;
-
     service
         .update(&team)
         .await

--- a/api/src/controllers/vendor.rs
+++ b/api/src/controllers/vendor.rs
@@ -114,8 +114,6 @@ pub async fn put(
         return Err(Error::InvalidParameters("id mismatch".to_string()));
     }
 
-    let vendor = vendor;
-
     service
         .update(&vendor)
         .await

--- a/sdk/core/src/services/github/client/mod.rs
+++ b/sdk/core/src/services/github/client/mod.rs
@@ -27,19 +27,26 @@ impl Client {
     /// Creates the URL one must use in an http request for
     /// acquiring the latest commit hash from a given branch
     fn get_last_commit_url(&self, repo: &Repo) -> String {
-        let repo_name = repo.full_name.as_ref().unwrap();
+        let full_name = repo.full_name.clone();
         let default_branch = repo.default_branch.as_ref().unwrap();
-        format!("{GH_URL}/repos/{repo_name}/commits/{default_branch}")
+        format!("{GH_URL}/repos/{full_name}/commits/{default_branch}")
+    }
+
+    /// Creates the URL one must use in an http request for
+    /// acquiring the latest commit hash from a given branch
+    fn get_latest_release_url(&self, repo: &Repo) -> String {
+        let full_name = repo.full_name.clone();
+        format!("{GH_URL}/repos/{full_name}/releases/latest")
     }
 
     /// Function to get the number of repos in the associated organization
     /// gets public, private and forked repos.
-    async fn get_num_repos(&self, org: String) -> Result<Option<u32>, Error> {
+    async fn get_num_repos(&self, org: &str) -> Result<Option<u32>, Error> {
         let org_url: String = format!("{GH_URL}/orgs/{org}");
 
         println!("==> Getting repositories from org, url: {} ", org_url);
 
-        let response: Result<Option<Org>, HyperError> = self
+        let option: Option<Org> = self
             .http_client
             .get(
                 org_url.as_str(),
@@ -47,34 +54,38 @@ impl Client {
                 self.token.as_str(),
                 None::<String>,
             )
-            .await;
+            .await
+            .map_err(Error::GitHubResponse)?;
 
-        match response {
-            Ok(option) => match option {
-                Some(value) => {
-                    let num_public_repos = value.public_repo_count;
-                    let num_private_repos = value.private_repo_count;
+        match option {
+            Some(value) => {
+                let num_public_repos = value.public_repo_count;
+                let num_private_repos = value.private_repo_count;
 
-                    println!(
-                        "Found {} public repos and {} private repos",
-                        num_public_repos, num_private_repos
-                    );
+                println!(
+                    "Found {} public repos and {} private repos",
+                    num_public_repos, num_private_repos
+                );
 
-                    Ok(Some(num_public_repos + num_private_repos))
-                }
-                None => Err(Error::GitHubErrorResponse(
-                    "==> Get request from GitHub had an empty response".to_string(),
-                )),
-            },
-            Err(err) => Err(Error::GitHubResponse(err)),
+                Ok(Some(num_public_repos + num_private_repos))
+            }
+
+            None => Err(Error::GitHubErrorResponse(String::from(
+                "==> Get request from GitHub had an empty response",
+            ))),
         }
     }
 
     /* Public */
 
     /// Get the last commit for a given Repo
-    pub async fn get_last_commit(&self, repo: &mut Repo) -> Result<Option<String>, Error> {
+    pub async fn get_last_commit(&self, repo: &Repo) -> Result<Option<String>, Error> {
         let github_last_commit_url = self.get_last_commit_url(repo);
+
+        println!(
+            "==> getting last commit for repo : {:#?}",
+            repo.full_name.clone()
+        );
 
         let response: Result<Option<Commit>, HyperError> = self
             .http_client
@@ -104,10 +115,31 @@ impl Client {
             }
         };
 
-        match gh_commits_rsp.last_hash {
-            Some(val) => Ok(Some(val)),
-            None => Ok(None),
-        }
+        Ok(gh_commits_rsp.last_hash)
+    }
+
+    /// Gets the latest release tag name from the GitHub repo
+    pub async fn get_latest_release_tag(&self, repo: &Repo) -> Result<String, Error> {
+        let latest_release_url = self.get_latest_release_url(repo);
+
+        println!(
+            "==> getting latest release for repo : {:#?}",
+            repo.full_name.clone()
+        );
+
+        let response: Result<Option<Release>, Error> = self
+            .http_client
+            .get(
+                latest_release_url.as_str(),
+                ContentType::Json,
+                self.token.as_str(),
+                None::<String>,
+            )
+            .await
+            .map_err(|err| Error::GitHubErrorResponse(format!("{}", err)));
+
+        let option = response.unwrap_or(Some(Release::new()));
+        Ok(option.unwrap_or(Release::new()).tag_name)
     }
 
     /// Conventional Constructor.
@@ -119,7 +151,7 @@ impl Client {
 
     /// Function to get the number of repos per page
     pub async fn get_pages(&self, org: &String) -> Result<Vec<u32>, Error> {
-        let num_repos = self.get_num_repos(org.to_string()).await?.unwrap_or(0);
+        let num_repos = self.get_num_repos(org.as_str()).await?.unwrap_or(0);
 
         println!("==> Number of Repositories in {}: {}", org, num_repos);
 
@@ -196,6 +228,7 @@ pub struct Org {
     private_repo_count: u32,
 }
 
+/// Function to provide a default  for the repo counts
 fn default_num_repos() -> u32 {
     0
 }
@@ -207,7 +240,7 @@ pub struct Repo {
     /// The name of the repo.  Getting the Full name
     /// is nice because it has teh "user" in it: <USER>>/<REPO>.git
     /// Ex: CMSgov/design-system.git
-    pub full_name: Option<String>,
+    pub full_name: String,
     /// Url of the repository.
     pub html_url: Option<String>,
     /// The default branch of the repo, usually master or main
@@ -225,6 +258,67 @@ pub struct Repo {
     /// hash of the default branch
     #[serde(default = "empty_string")]
     pub last_hash: String,
+    /// Latest release tag name
+    #[serde(default = "empty_string")]
+    pub version: String,
+}
+
+/// Repo impl
+impl Repo {
+    /// Conventional Constructor
+    pub fn new() -> Self {
+        Repo {
+            full_name: String::from(""),
+            html_url: None,
+            default_branch: None,
+            language: None,
+            archived: None,
+            disabled: None,
+            empty: default_bool(),
+            last_hash: empty_string(),
+            version: empty_string(),
+        }
+    }
+
+    /// This method allows us to add the last hash to a
+    /// Repo if it is newer that what is already in Mongo
+    pub fn add_last_hash(&mut self, last_hash: String) {
+        self.last_hash = last_hash;
+    }
+
+    /// Method to add a version
+    pub fn add_version(&mut self, version: String) {
+        self.version = version;
+    }
+
+    /// Method to mark the Repository as empty
+    pub fn mark_repo_empty(&mut self) {
+        self.empty = true;
+    }
+}
+
+/// Default Implementation
+impl Default for Repo {
+    fn default() -> Self {
+        Repo::new()
+    }
+}
+
+/// The Release struct is used to collect data from a response
+/// from the /repos/{org}/{repo_name}/releases/latest endpoint.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Release {
+    /// The tag name associated to the release
+    #[serde(default = "default_version")]
+    pub tag_name: String,
+}
+
+impl Release {
+    fn new() -> Self {
+        Release {
+            tag_name: default_version(),
+        }
+    }
 }
 
 /// Little function to define default booleans
@@ -239,27 +333,43 @@ fn empty_string() -> String {
     "".to_string()
 }
 
-/// Repo impl
-impl Repo {
-    /// This method allows us to add the last hash to a
-    /// Repo if it is newer that what is already in Mongo
-    ///
-    pub fn add_last_hash(&mut self, last_hash: String) {
-        self.last_hash = last_hash;
-    }
-
-    /// Method to mark the Repository as empty
-    ///
-    pub fn mark_repo_empty(&mut self) {
-        self.empty = true;
-    }
+/// Function used to define a default version for Harbor generated purls.
+/// The GitHub Provider currently requests the release tags from each repository
+/// and selects the latest tag name to use as the purl version.  If no tag exists,
+/// then this version is used instead.  The 'd' in the version is used to flag that
+/// the version is the default version that came from this function while the form
+/// of a semantic version "0.0.0" is used to easily recognize that the string is a
+/// version.
+pub fn default_version() -> String {
+    String::from("d0.0.0")
 }
 
 #[cfg(test)]
 mod test {
-    use crate::services::github::client::Client;
+    use crate::services::github::client::{Client, Repo};
     use crate::services::github::error::Error;
     use platform::config::from_env;
+
+    /// Requires GITHUB_PAT environment variable
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn test_get_last_release() -> Result<(), Error> {
+        let pat = match from_env("GITHUB_PAT") {
+            Some(v) => v,
+            None => panic!("No GITHUB_PAT in environment"), // test panic
+        };
+
+        let client = Client::new(pat);
+
+        let mut repo: Repo = Repo::default();
+        repo.full_name = String::from("harbor-test-org/java-multi-module");
+
+        let release = client.get_latest_release_tag(&repo).await?;
+
+        assert_eq!("0.0.2", release);
+
+        Ok(())
+    }
 
     /// This test must be run with a GitHub PAT that has the correct permissions
     /// Fine grained PATs do not work, the token must be a classic PAT with these perms:

--- a/sdk/core/src/services/snyk/adapters.rs
+++ b/sdk/core/src/services/snyk/adapters.rs
@@ -31,6 +31,7 @@ impl Group {
 }
 
 /// Adapter over a native Snyk Org.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct Organization {
     pub id: String,
     pub name: String,

--- a/sdk/core/src/tasks/sboms/github/mod.rs
+++ b/sdk/core/src/tasks/sboms/github/mod.rs
@@ -4,31 +4,19 @@ pub mod sync;
 use std::collections::HashMap;
 pub use sync::*;
 
-/// Temporary way to associate build files with Syft catalogers.  Syft
-/// can use the same cataloger for multiple types of files, that is the reason
-/// we need to use a vector to manage them.
-pub fn get_cataloger_to_build_target_map() -> HashMap<String, Vec<String>> {
-    let mut map = HashMap::new();
+lazy_static! {
 
-    // Add java pom.xml
-    map.insert("java-pom".to_string(), vec!["pom.xml".to_string()]);
-
-    // Add support for finding javascript build files
-    map.insert(
-        "javascript-package".to_string(),
-        vec!["package.json".to_string()],
-    );
-
-    // Add support for python requirements.txt build files
-    map.insert(
-        "python-index".to_string(),
-        vec!["requirements.txt".to_string()],
-    );
-
-    // Add support for Ruby Gemfiles
-    map.insert("ruby-gemfile".to_string(), vec!["Gemfile".to_string()]);
-
-    map
+    /// Static HashMap of Syft catalogers to build targets. This is used to associate
+    /// build files with Syft catalogers.  Syft can use the same cataloger for multiple
+    /// types of files, that is the reason we need to use a vector to manage them.
+    static ref BUILD_TARGETS: HashMap<&'static str, Vec<&'static str>> = {
+            HashMap::from([
+            ("java-pom-cataloger", vec!["pom.xml"]),
+            ("javascript-package-cataloger", vec!["package.json"]),
+            ("python-index-cataloger", vec!["requirements.txt"]),
+            ("ruby-gemfile-cataloger", vec!["Gemfile"]),
+        ])
+    };
 }
 
 #[cfg(test)]

--- a/sdk/core/src/tasks/sboms/snyk/sync.rs
+++ b/sdk/core/src/tasks/sboms/snyk/sync.rs
@@ -98,7 +98,7 @@ impl SyncTask {
     pub(crate) async fn process_target(
         &self,
         task: &Task,
-        project: &mut Project,
+        project: &Project,
     ) -> Result<(), Error> {
         if project.status == ProjectStatus::Inactive {
             self.handle_inactive(project)?;


### PR DESCRIPTION
## Summary

Syft service will generate a purl using the correct type instead of a cataloger

### Changed

1. The generate_stopgap_purl() function is renamed to generate_purl() and it now uses the CATALOGERS static hashmap to lookup the actual purl type from the cataloger used to generate the SBOM.
2. The function get_cataloger_to_build_target_map() has been removed and a BUILD_TARGETS static HashMap has been created to use instead.

## How to test

1. Set up test environment
2. Run GitHub Provider: `/target/debug/harbor ingest -p github harbor-test-org --debug`
3. Verify that all purls have types except `no-type`, which a discussion is planned to handle
4. Verify that all purls fit the purl specification: https://github.com/package-url/purl-spec