### PR TITLE
cicd: refactor workflow to free disk space

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 27017:27017
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.2.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,8 +18,6 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.68.0
     services:
       mongo:
         image: mongo:5.0.15
@@ -32,6 +30,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.2.0
+
       - name: Install latest sbom-scorecard
         run: |
           wget -O /usr/local/bin/scorecard https://github.com/eBay/sbom-scorecard/releases/download/0.0.7/sbom-scorecard-linux-amd64

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install latest sbom-scorecard
         run: |
-          wget -O /usr/local/bin/scorecard https://github.com/eBay/sbom-scorecard/releases/download/0.0.7/sbom-scorecard-linux-amd64
+          wget -q -O /usr/local/bin/scorecard https://github.com/eBay/sbom-scorecard/releases/download/0.0.7/sbom-scorecard-linux-amd64
           chmod u+x /usr/local/bin/scorecard
 
       - name: Install latest syft

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ to our [book](https://cms-enterprise.github.io/sbom-harbor/) for a comprehensive
 
 ## Status
 
-Harbor is under active development. We are currently working at a `0.1.0` pre-release semver level. 
-There is no guarantee of stable interfaces or backward compatability at this time. We would be 
-thrilled to have additional contributors and end-users, but we want to make sure you are aware 
+Harbor is under active development. We are currently working at a `0.1.0` pre-release semver level.
+There is no guarantee of stable interfaces or backward compatability at this time. We would be
+thrilled to have additional contributors and end-users, but we want to make sure you are aware
 of that before you decide to invest your time and resources.
 
 ## Developer System Requirements
@@ -65,23 +65,15 @@ cd sbom-harbor
 pre-commit install
 ```
 
-3. Depending on your development environment, you may also need to add the following to your
-   `/etc/hosts` file.
-
-```shell
-# Harbor DevEnv
-127.0.0.1 mongo
-```
-
 ## Project Documentation
 
 Project documentation and additional developer guidance can be found on our [GitPage](https://cms-enterprise.github.io/sbom-harbor/).
 
 ## Crate Documentation
 
-The documentation for each crate can be generated from source using `cargo` or `rustdoc`. We 
-plan to integrate the `rustdoc` output with the[project documentation](#project-documentation) 
-in time. However, that requires additional tooling that we haven't gotten to yet. That would 
+The documentation for each crate can be generated from source using `cargo` or `rustdoc`. We
+plan to integrate the `rustdoc` output with the[project documentation](#project-documentation)
+in time. However, that requires additional tooling that we haven't gotten to yet. That would
 make a great first contribution. If you are willing, a PR will definitely be considered.
 
 To generate the crate documentation, clone the repository, and then run the
@@ -123,7 +115,7 @@ out each one.
 
 ### Local Development Environment
 
-If you wish to run Harbor locally using the development environment found in the `sdk/devenv` 
+If you wish to run Harbor locally using the development environment found in the `sdk/devenv`
 directory,
 open a new terminal and run the following command.
 
@@ -133,10 +125,10 @@ cd sdk/devenv && docker compose up
 
 ### Sbom Ingestion & Enrichment
 
-Many teams at CMS have been onboarded to Snyk. That fact made a Snyk integration an appealing 
-first target. Currently, Harbor supports ingesting SBOMs using the Snyk API. A generic GitHub 
-ingestion provider is imminent. Similarly, an enrichment provider based on an Open Source 
-vulnerability data provider is on the short-term roadmap. Stay tuned for updates on how to get 
+Many teams at CMS have been onboarded to Snyk. That fact made a Snyk integration an appealing
+first target. Currently, Harbor supports ingesting SBOMs using the Snyk API. A generic GitHub
+ingestion provider is imminent. Similarly, an enrichment provider based on an Open Source
+vulnerability data provider is on the short-term roadmap. Stay tuned for updates on how to get
 started with purely Open Source tools.
 
 Make sure all environment variables are set and then run the following command.

--- a/sdk/core/src/config.rs
+++ b/sdk/core/src/config.rs
@@ -36,7 +36,7 @@ pub fn dev_context(db_name: Option<&str>) -> Result<Context, Error> {
     };
 
     Ok(Context {
-        host: "mongo".to_string(),
+        host: "localhost".to_string(),
         username: "root".to_string(),
         password: "harbor".to_string(),
         port: 27017,

--- a/sdk/devenv/docker-compose.yml
+++ b/sdk/devenv/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=harbor
-    hostname: mongo
     ports:
       - "27017:27017"
     command: mongod

--- a/sdk/platform/src/persistence/mongodb/analytics.rs
+++ b/sdk/platform/src/persistence/mongodb/analytics.rs
@@ -156,7 +156,7 @@ pub fn test_context(db_name: Option<&str>) -> Result<Context, Error> {
     };
 
     Ok(Context {
-        host: "mongo".to_string(),
+        host: "localhost".to_string(),
         username: "root".to_string(),
         password: "harbor".to_string(),
         port: 27017,

--- a/sdk/platform/src/persistence/mongodb/mod.rs
+++ b/sdk/platform/src/persistence/mongodb/mod.rs
@@ -111,7 +111,7 @@ mod tests {
 
     fn context() -> Context {
         Context {
-            host: "mongo".to_string(),
+            host: "localhost".to_string(),
             username: "root".to_string(),
             password: "harbor".to_string(),
             port: 27017,

--- a/sdk/platform/tests/common/mongodb.rs
+++ b/sdk/platform/tests/common/mongodb.rs
@@ -14,7 +14,7 @@ pub const COLLECTION: &str = "Group";
 
 pub async fn local_context() -> Result<Context, Error> {
     let cx: Context = Context {
-        host: "mongo".to_string(),
+        host: "localhost".to_string(),
         username: "root".to_string(),
         password: "harbor".to_string(),
         port: 27017,


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/ISPGCASP/) to the PR title like this `[ISPGCASP-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

Other PRs were failing because the disk was filling up during compilation. This PRs addresses this by removing the `container: rust:1.68.0` that caused a docker in docker situation. This then allows the new action to free disk space under the primary ubuntu container.

### Added

none

### Changed

Workflow no longer uses docker in docker, now uses rust on ubuntu, with a new action to free disk space. This necessitated a change to address mongo at `localhost:` rather than `mongo:`

### Deprecated

none

### Removed

none

### Fixed

Fixes an issue in the github actions where Test step would fail because of the lack of disk space

## How to test

Can only be tested in github actions