### PR TITLE
fix: ensure the pipeline is cleared on every iteration in analytic pipeline

### DIFF
--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -338,7 +338,9 @@ impl AnalyticService {
 
     /// Generates a Detail Analytic Report. Specification is here:
     pub(crate) async fn generate_detail(&self, purl: String) -> Result<Option<String>, Error> {
+        println!("==> pipeline stages on enter {}", self.pipeline.len());
         self.pipeline.clear();
+        println!("==> pipeline stages after clear {}", self.pipeline.len());
 
         self.pipeline
             .add_stage(report_analytic_stage_1(purl.clone()));
@@ -380,6 +382,8 @@ impl AnalyticService {
                 )))
             }
         };
+
+        println!("==> pipeline stages after execute {}", self.pipeline.len());
 
         match self
             .storage
@@ -521,9 +525,9 @@ mod tests {
             service.pipeline.add_stage(report_analytic_stage_10());
             service.pipeline.add_stage(report_analytic_stage_11());
 
-            assert_eq!(service.pipeline.stages.lock().unwrap().len(), 15);
+            assert_eq!(service.pipeline.len(), 15);
             service.pipeline.clear();
-            assert_eq!(service.pipeline.stages.lock().unwrap().len(), 0);
+            assert!(service.pipeline.is_empty());
         }
 
         Ok(())

--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -338,6 +338,8 @@ impl AnalyticService {
 
     /// Generates a Detail Analytic Report. Specification is here:
     pub(crate) async fn generate_detail(&self, purl: String) -> Result<Option<String>, Error> {
+        self.pipeline.clear();
+
         self.pipeline
             .add_stage(report_analytic_stage_1(purl.clone()));
 
@@ -479,5 +481,51 @@ mod tests {
         assert!(result.is_ok());
         let path = result.unwrap().unwrap();
         assert!(path.contains("pkg:npm/bic-api@1.0.0"));
+    }
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn can_clear_pipeline() -> Result<(), Error> {
+        // Mock store and storage provider
+        let cxt: &Context = &test_context(Some("harbor")).expect("Unable to create a test context");
+        let raw_store = MongoStore::new(cxt)
+            .await
+            .expect("Unable to unwrap MongoStore");
+        let store = Arc::new(raw_store);
+        let storage = Arc::new(MockStorageProvider);
+
+        let service = AnalyticService {
+            store: store.clone(),
+            storage,
+            pipeline: Pipeline::new(store),
+        };
+
+        let primary_purls = service.get_primary_purls().await?.unwrap();
+
+        for purl in primary_purls {
+            println!("==> generating detail report for purl {}", purl);
+
+            service.pipeline.add_stage(report_analytic_stage_1(purl));
+            service.pipeline.add_stage(sort_by_timestamp_desc());
+            service.pipeline.add_stage(limit_1());
+            service.pipeline.add_stage(fisma_xref_array());
+            service.pipeline.add_stage(fisma_xref());
+            service.pipeline.add_stage(report_analytic_stage_2());
+            service.pipeline.add_stage(report_analytic_stage_3());
+            service.pipeline.add_stage(report_analytic_stage_4_and_7());
+            service.pipeline.add_stage(report_analytic_stage_5());
+            service.pipeline.add_stage(report_analytic_stage_6());
+            service.pipeline.add_stage(report_analytic_stage_4_and_7());
+            service.pipeline.add_stage(report_analytic_stage_8());
+            service.pipeline.add_stage(report_analytic_stage_9());
+            service.pipeline.add_stage(report_analytic_stage_10());
+            service.pipeline.add_stage(report_analytic_stage_11());
+
+            assert_eq!(service.pipeline.stages.lock().unwrap().len(), 15);
+            service.pipeline.clear();
+            assert_eq!(service.pipeline.stages.lock().unwrap().len(), 0);
+        }
+
+        Ok(())
     }
 }

--- a/sdk/platform/src/persistence/mongodb/analytics.rs
+++ b/sdk/platform/src/persistence/mongodb/analytics.rs
@@ -19,7 +19,7 @@ pub struct Pipeline {
     store: Arc<Store>,
     /// This variable holds all of the Stages to be executed
     /// in the pipeline.
-    stages: Mutex<Vec<Stage>>,
+    pub stages: Mutex<Vec<Stage>>,
 }
 
 impl Pipeline {

--- a/sdk/platform/src/persistence/mongodb/analytics.rs
+++ b/sdk/platform/src/persistence/mongodb/analytics.rs
@@ -19,7 +19,7 @@ pub struct Pipeline {
     store: Arc<Store>,
     /// This variable holds all of the Stages to be executed
     /// in the pipeline.
-    pub stages: Mutex<Vec<Stage>>,
+    stages: Mutex<Vec<Stage>>,
 }
 
 impl Pipeline {
@@ -41,6 +41,16 @@ impl Pipeline {
         self.stages.lock().unwrap().clear();
     }
 
+    /// Gets the current count of stages in the pipeline.
+    pub fn len(&self) -> usize {
+        self.stages.lock().unwrap().len()
+    }
+
+    /// Indicates whether the current pipeline has any queued stages.
+    pub fn is_empty(&self) -> bool {
+        self.stages.lock().unwrap().is_empty()
+    }
+
     /// This method executes the Analytic and returns the results as a Serde Value
     pub async fn execute_on(&self, collection: &str) -> Result<Value, Error> {
         if self.stages.lock().unwrap().len() == 0 {
@@ -54,7 +64,7 @@ impl Pipeline {
         let collection = db.collection::<Document>(collection);
 
         // Set the options for the aggregation
-        let options = AggregateOptions::builder().build();
+        let options = AggregateOptions::builder().allow_disk_use(true).build();
 
         // Map the stages over to Documents
         let doc_pipeline = self


### PR DESCRIPTION

## Summary

Fixes 2 issues in the aggregation pipeline.   Closes #128 

### Fixed

- Set an option on the pipeline `AggregateOptions` to allow DocumentDB to page to disk if necessary for large aggregation results
- Modified the SBOM detail Task to clear the pipeline upon entry to the `generate_detail` function, thus ensuring that any previous processing errors don't result in aggregate count exceeded errors.
- Added logging to monitor that pipeline stages are being managed as expected.

## How to test

Run the sbom detail report in prod and inspect logs.
