### PR TITLE
feat(add-go-support): added suport for go.mod files

### DIFF
--- a/sdk/core/src/tasks/sboms/github/mod.rs
+++ b/sdk/core/src/tasks/sboms/github/mod.rs
@@ -16,6 +16,7 @@ lazy_static! {
             ("python-index-cataloger", vec!["requirements.txt"]),
             ("ruby-gemfile-cataloger", vec!["Gemfile"]),
             ("rust-cargo-lock-cataloger", vec!["Cargo.lock"]),
+            ("go-mod-file-cataloger", vec!["go.mod"]),
         ])
     };
 }


### PR DESCRIPTION
## Summary

Added support for GItHub ingest provider for processing repos that have code written in Go and have go.mod files.  

### Added

New build target(go.mod) and associated Syft cataloger(go-mod-file-cataloger). 

## How to test

1. Make sure MongoDB is running locally
2. Build the code with `cargo build`
3. Run command: `/target/debug/harbor ingest -p github harbor-test-org --debug`
4. Open MongoDB Compass
5. In the `Packages` collection, add filter: `{ kind: "primary", purl: /golang/ }`
6. Verify a package exists with the purl: `pkg:golang/harbor-test-org/go-project-with-mod@d0.0.0`