### PR TITLE
feat(cpe-enrichment): add a purl to cpe enrichment source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with 2.3.3",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -1600,6 +1601,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid",
 ]
 
@@ -3120,6 +3122,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,6 +3793,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -9,6 +9,7 @@ async fn main() -> Result<(), Error> {
         Some(Commands::Ingest(ingest)) => commands::ingest::execute(ingest).await,
         Some(Commands::Analyze(analyze)) => commands::analyze::execute(analyze).await,
         Some(Commands::Health(health)) => commands::health::execute(health).await,
+        Some(Commands::Construct(construct)) => commands::construct::execute(construct).await,
         _ => {
             println!("command not found");
             std::process::exit(1);

--- a/cli/src/commands/analyze/sbom_detail.rs
+++ b/cli/src/commands/analyze/sbom_detail.rs
@@ -40,7 +40,7 @@ pub(crate) async fn execute(args: &AnalyzeArgs) -> Result<(), Error> {
             .map_err(|e| Error::Analyze(e.to_string()))?,
     );
 
-    let provider = DetailTask::new(AnalyticService::new(store, storage));
+    let provider = DetailTask::new(AnalyticService::new(store, Some(storage)));
 
     match &args.detail_args {
         None => {

--- a/cli/src/commands/construct/mod.rs
+++ b/cli/src/commands/construct/mod.rs
@@ -1,0 +1,39 @@
+use crate::Error;
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
+
+mod purl2cpe;
+
+/// The CommandFactory function for the `construct` command.
+pub async fn execute(args: &ConstructArgs) -> Result<(), Error> {
+    match args.provider {
+        ConstructionProviderKind::Purl2Cpe => purl2cpe::execute(args).await,
+    }
+}
+
+/// Enumerates which construction provider to employ.
+#[derive(Clone, Debug)]
+pub(crate) enum ConstructionProviderKind {
+    /// Generate a Detailed report from SBOM data.
+    Purl2Cpe,
+}
+
+impl ValueEnum for ConstructionProviderKind {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Purl2Cpe]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            ConstructionProviderKind::Purl2Cpe => PossibleValue::new("purl2cpe")
+                .help("Generates a dataset from the purl2cpe GitHub Repository: https://github.com/scanoss/purl2cpe."),
+        })
+    }
+}
+
+/// Specifies the CLI args for the `construct` command.
+#[derive(Debug, Parser)]
+pub struct ConstructArgs {
+    /// Specifies the kind of provider
+    provider: ConstructionProviderKind,
+}

--- a/cli/src/commands/construct/purl2cpe.rs
+++ b/cli/src/commands/construct/purl2cpe.rs
@@ -1,0 +1,56 @@
+use crate::commands::construct::ConstructArgs;
+use crate::Error;
+use harbcore::entities::datasets::ConstructionProviderKind;
+use harbcore::entities::tasks::{Task, TaskKind};
+use harbcore::tasks::TaskProvider;
+use platform::persistence::mongodb::Store;
+use std::sync::Arc;
+
+use harbcore::services::purl2cpe::service::Purl2CpeService;
+use harbcore::tasks::construction::dataset::purl2cpe::ConstructionTask;
+
+pub(crate) async fn execute(_args: &ConstructArgs) -> Result<(), Error> {
+    println!("==> Beginning purl2cpe dataset construction");
+
+    let cx = harbcore::config::harbor_context().map_err(|e| Error::Config(e.to_string()))?;
+
+    let store = Arc::new(
+        Store::new(&cx)
+            .await
+            .map_err(|e| Error::Construction(e.to_string()))?,
+    );
+
+    let service = Purl2CpeService::new(store);
+    let provider = ConstructionTask::new(service);
+    let provider_kind = ConstructionProviderKind::Purl2Cpe;
+    let task_kind = TaskKind::Construction(provider_kind);
+    let mut task: Task = Task::new(task_kind).map_err(|e| Error::Construction(e.to_string()))?;
+
+    provider
+        .execute(&mut task)
+        .await
+        .map_err(|e| Error::Construction(e.to_string()))?;
+
+    println!("==> Purl2Cpe data set construction complete");
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::commands::construct::{execute, ConstructArgs, ConstructionProviderKind};
+    use crate::Error;
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn execute_purl2cpe_dataset_construction() -> Result<(), Error> {
+        let args = ConstructArgs {
+            provider: ConstructionProviderKind::Purl2Cpe,
+        };
+
+        execute(&args)
+            .await
+            .expect("Panic at github ingest provider execute!");
+
+        Ok(())
+    }
+}

--- a/cli/src/commands/enrich/mod.rs
+++ b/cli/src/commands/enrich/mod.rs
@@ -7,6 +7,8 @@ use std::str::FromStr;
 
 /// EPSS enrichment command handler.
 pub mod epss;
+/// Purl2cpe enrichment command handler.
+mod purl2cpe;
 /// Sbom Scorecard enrichment command handler.
 pub mod sbom_scorecard;
 /// Snyk enrichment command handler.
@@ -21,6 +23,8 @@ pub enum EnrichmentProviderKind {
     Snyk,
     /// Use the sbom-scorecard enrichment provider
     SbomScorecard,
+    /// Use the Purl to Cpe enrichment provider
+    Purl2Cpe,
 }
 
 /// The CommandFactory function for the `enrich` command.
@@ -29,12 +33,13 @@ pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
         EnrichmentProviderKind::Epss => epss::execute(args).await,
         EnrichmentProviderKind::Snyk => snyk::execute(args).await,
         EnrichmentProviderKind::SbomScorecard => SbomScorecardProvider::execute(args).await,
+        EnrichmentProviderKind::Purl2Cpe => purl2cpe::execute(args).await,
     }
 }
 
 impl ValueEnum for EnrichmentProviderKind {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Epss, Self::Snyk, Self::SbomScorecard]
+        &[Self::Epss, Self::Snyk, Self::SbomScorecard, Self::Purl2Cpe]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
@@ -42,6 +47,7 @@ impl ValueEnum for EnrichmentProviderKind {
             Self::Epss => PossibleValue::new("epss").help("Run EPSS enrichment"),
             Self::Snyk => PossibleValue::new("snyk").help("Run Snyk enrichment"),
             Self::SbomScorecard => PossibleValue::new("sbom-scorecard").help("Run Sbom Scorecard"),
+            Self::Purl2Cpe => PossibleValue::new("purl2cpe").help("Run purl2cpe"),
         })
     }
 }
@@ -54,6 +60,7 @@ impl FromStr for EnrichmentProviderKind {
         let value = value.as_str();
         match value {
             "epss" => Ok(EnrichmentProviderKind::Epss),
+            "purl2cpe" => Ok(EnrichmentProviderKind::Purl2Cpe),
             "snyk" | "s" => Ok(EnrichmentProviderKind::Snyk),
             "sbom-scorecard" | "score" => Ok(EnrichmentProviderKind::SbomScorecard),
             _ => Err(()),

--- a/cli/src/commands/enrich/purl2cpe.rs
+++ b/cli/src/commands/enrich/purl2cpe.rs
@@ -1,0 +1,61 @@
+use harbcore::entities::enrichments::VulnerabilityProviderKind;
+use std::sync::Arc;
+
+use crate::commands::enrich::EnrichArgs;
+use harbcore::entities::tasks::{Task, TaskKind};
+use harbcore::services::analytics::sboms::service::AnalyticService;
+use harbcore::services::purl2cpe::service::Purl2CpeService;
+use harbcore::tasks::enrichments::identity::cpe::sync::SyncTask;
+use harbcore::tasks::TaskProvider;
+use platform::persistence::mongodb::Store;
+
+use crate::Error;
+
+/// Concrete implementation of the command handler. Responsible for
+/// dispatching command to the correct logic handler based on args passed.
+pub async fn execute(args: &EnrichArgs) -> Result<(), Error> {
+    println!("Executing purl2cpe enrichment provider");
+
+    let cx = match &args.debug {
+        false => harbcore::config::harbor_context().map_err(|e| Error::Config(e.to_string()))?,
+        true => harbcore::config::dev_context(None).map_err(|e| Error::Config(e.to_string()))?,
+    };
+
+    let store = Arc::new(
+        Store::new(&cx)
+            .await
+            .map_err(|e| Error::Enrich(e.to_string()))?,
+    );
+
+    let analytic_service = AnalyticService::new(store.clone(), None);
+    let purl_2_cpe_service = Purl2CpeService::new(store.clone());
+    let provider = SyncTask::new(store, analytic_service, purl_2_cpe_service);
+
+    let task_kind = TaskKind::Vulnerabilities(VulnerabilityProviderKind::Purl2Cpe);
+    let mut task: Task = Task::new(task_kind).map_err(|e| Error::Enrich(e.to_string()))?;
+
+    provider
+        .execute(&mut task)
+        .await
+        .map_err(|e| Error::Enrich(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::execute;
+    use crate::commands::enrich::{EnrichArgs, EnrichmentProviderKind};
+    use crate::Error;
+
+    #[async_std::test]
+    #[ignore = "debug manual only"]
+    async fn can_execute() -> Result<(), Error> {
+        let args = EnrichArgs {
+            provider: EnrichmentProviderKind::Purl2Cpe,
+            debug: true,
+            snyk_args: None,
+            sbom_scorecard_args: None,
+        };
+
+        execute(&args).await
+    }
+}

--- a/cli/src/commands/ingest/github.rs
+++ b/cli/src/commands/ingest/github.rs
@@ -95,8 +95,8 @@ mod test {
         };
 
         execute(&ingest_args)
-        .await
-        .expect("Panic at github ingest provider execute!");
+            .await
+            .expect("Panic at github ingest provider execute!");
         Ok(())
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,3 +9,6 @@ pub mod analyze;
 
 /// Contains functions to support the `health` Command.
 pub mod health;
+
+/// Contains the types and functions to support the `construct` command
+pub mod construct;

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -27,6 +27,9 @@ pub enum Error {
     /// Sbom runtime error.
     #[error("sbom: {0}")]
     Sbom(String),
+    /// Construction runtime error.
+    #[error("construction: {0}")]
+    Construction(String),
 }
 
 impl From<harbcore::Error> for Error {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -29,6 +29,8 @@ pub struct Cli {
 /// The set of supported Commands.
 #[derive(Debug, Subcommand)]
 pub enum Commands {
+    /// Construct a data set
+    Construct(commands::construct::ConstructArgs),
     /// Enrich an SBOM.
     Enrich(commands::enrich::EnrichArgs),
     /// Ingest one or more SBOMs from a directory or from an external SBOM Provider.

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -20,6 +20,7 @@ regex = "1.7.3"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 serde_json = "1.0.87"
+serde_yaml = "0.9.25"
 serde_with = "2.3.0"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
@@ -28,6 +29,7 @@ thiserror = "1.0"
 tower-http = { version = "0.3.5", features = ["cors"]}
 url = "2.3.1"
 uuid = "1.3.0"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }

--- a/sdk/core/src/config.rs
+++ b/sdk/core/src/config.rs
@@ -55,8 +55,7 @@ pub fn harbor_context() -> Result<Context, Error> {
         Some(raw_config) => raw_config,
     };
 
-    let cfg: DocDbConfig = serde_json::from_str(raw_config.as_str())
-        .map_err(|e| Error::Serde(format!("invalid DocumentDB config::{}", e)))?;
+    let cfg: DocDbConfig = serde_json::from_str(raw_config.as_str()).map_err(Error::Serde)?;
 
     Ok(cfg.to_context())
 }

--- a/sdk/core/src/entities/cyclonedx/mod.rs
+++ b/sdk/core/src/entities/cyclonedx/mod.rs
@@ -32,10 +32,7 @@ impl Bom {
     pub fn parse(raw: &str, format: CdxFormat) -> Result<Bom, Error> {
         match format {
             CdxFormat::Json => {
-                let bom = serde_json::from_str::<Bom>(raw).map_err(|e| {
-                    Error::Serde(format!("error serializing CycloneDx SBOM - {}", e))
-                })?;
-
+                let bom = serde_json::from_str::<Bom>(raw).map_err(Error::Serde)?;
                 Ok(bom)
             }
             CdxFormat::Xml => Err(Error::Runtime("CycloneDx XML not supported".to_string())),

--- a/sdk/core/src/entities/datasets/mod.rs
+++ b/sdk/core/src/entities/datasets/mod.rs
@@ -1,0 +1,136 @@
+use platform::mongo_doc;
+use platform::persistence::mongodb::MongoDocument;
+use serde_derive::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+/// Common Platform Enumeration (CPE) is a structured naming scheme for information
+/// technology systems, software, and packages. Based upon the generic syntax for
+/// Uniform Resource Identifiers (URI), CPE includes a formal name format, a method
+/// for checking names against a system, and a description format for binding text
+/// and tests to a name.
+pub struct Cpe {
+    /// Place to store the original string to return later
+    original_cpe_string: String,
+    /// "cpe" string literal
+    pub cpe: String,
+    /// The version of the CPE definition. The latest CPE definition version is 2.3.
+    pub cpe_version: String,
+    /// May have 1 of 3 values:
+    /// 1. a for Applications
+    /// 2. h for Hardware
+    /// 3. o for Operating Systems
+    pub part: String,
+    /// Values for this attribute SHOULD describe or identify the person or organization
+    /// that manufactured or created the product. Values for this attribute SHOULD be
+    /// selected from an attribute-specific valid-values list, which MAY be defined by
+    /// other specifications that utilize this specification. Any character string meeting
+    /// the requirements for WFNs (cf. 5.3.2) MAY be specified as the value of the attribute
+    pub vendor: String,
+    /// The name of the system/package/component. product and vendor are sometimes identical.
+    /// It can not contain spaces, slashes, or most special characters. An underscore should
+    /// be used in place of whitespace characters.
+    pub product: String,
+    /// The version of the system/package/component.
+    pub version: String,
+    /// This is used for update or service pack information. Sometimes referred to as
+    /// "point releases" or minor versions. The technical difference between version and update
+    /// will be different for certain vendors and products. Common examples include beta, update4,
+    /// SP1, and ga (for General Availability), but it is most often left blank.
+    pub update: String,
+    /// A further granularity describing the build of the system/package/component, beyond version.
+    pub edition: String,
+    /// A valid language tag as defined by IETF RFC 4646 entitled "Tags for Identifying Languages".
+    /// Examples include: en-us for US English, and zh-tw for Taiwanese Mandarin.
+    pub language: String,
+    /// The Software Edition Component is used to define specific target software architectures
+    /// that need to be named
+    pub sw_edition: String,
+    /// The operating system the software was built to run on
+    pub target_sw: String,
+    /// The hardware the software was built to run on
+    pub target_hw: String,
+    /// Ancillary information
+    pub other: String,
+}
+
+impl Cpe {
+    /// Conventional Constructor
+    pub fn new(cpe: String) -> Self {
+        let cpe_parts = cpe.split(':').collect::<Vec<&str>>();
+        Self {
+            original_cpe_string: cpe.clone(),
+            cpe: cpe_parts[0].to_string(),
+            cpe_version: cpe_parts[1].to_string(),
+            part: cpe_parts[2].to_string(),
+            vendor: cpe_parts[3].to_string(),
+            product: cpe_parts[4].to_string(),
+            version: cpe_parts[5].to_string(),
+            update: cpe_parts[6].to_string(),
+            edition: cpe_parts[7].to_string(),
+            language: cpe_parts[8].to_string(),
+            sw_edition: cpe_parts[9].to_string(),
+            target_sw: cpe_parts[10].to_string(),
+            target_hw: cpe_parts[11].to_string(),
+            other: cpe_parts[12].to_string(),
+        }
+    }
+
+    /// Function to return the original string
+    pub fn get_string(&self) -> String {
+        self.original_cpe_string.clone()
+    }
+}
+
+/// Struct used to create an entry in the data set collection.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Purl2Cpes {
+    /// Storing the purl as the id because the purls must be unique
+    pub id: String,
+    /// All the associated cpes to the given purl
+    pub cpes: Vec<String>,
+}
+mongo_doc!(Purl2Cpes);
+
+/// Inner structure to hold an object with an id and the purl so we can
+/// update mongo later using the regular MongoDB persistence API
+#[derive(Deserialize, Debug, Clone)]
+pub struct PurlPlusId {
+    pub(crate) id: String,
+    pub(crate) purl: String,
+}
+
+impl Purl2Cpes {
+    /// Conventional constructor
+    pub fn new(purl: String, cpes: Vec<String>) -> Self {
+        Self { id: purl, cpes }
+    }
+}
+
+/// Tiny struct to hold a deserialized vector of purls
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PurlsContainer {
+    /// A vector of Purls as defined by
+    pub purls: Vec<String>,
+}
+
+/// Tiny struct to hold a deserialized vector of cpes
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CpesContainer {
+    /// a vector of Cpes that are associated to a given Purl
+    pub cpes: Vec<String>,
+}
+
+/// Enum to specify the Construction kind.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ConstructionProviderKind {
+    /// Data set kind for building a Purl -> Cpe.
+    Purl2Cpe,
+}
+
+impl Display for ConstructionProviderKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConstructionProviderKind::Purl2Cpe => write!(f, "purl-2-cpe"),
+        }
+    }
+}

--- a/sdk/core/src/entities/enrichments/vulnerabilities.rs
+++ b/sdk/core/src/entities/enrichments/vulnerabilities.rs
@@ -85,6 +85,8 @@ pub enum VulnerabilityProviderKind {
     IonChannel,
     /// Snyk provider.
     Snyk,
+    /// Purl2Cpe provider.
+    Purl2Cpe,
     /// Custom provider.
     Custom(String),
 }
@@ -95,6 +97,7 @@ impl Display for VulnerabilityProviderKind {
             VulnerabilityProviderKind::Epss => write!(f, "epss"),
             VulnerabilityProviderKind::IonChannel => write!(f, "ion-channel"),
             VulnerabilityProviderKind::Snyk => write!(f, "snyk"),
+            VulnerabilityProviderKind::Purl2Cpe => write!(f, "purl2cpe"),
             VulnerabilityProviderKind::Custom(name) => write!(f, "custom-{}", name),
         }
     }

--- a/sdk/core/src/entities/mod.rs
+++ b/sdk/core/src/entities/mod.rs
@@ -31,3 +31,6 @@ pub mod enrichments;
 
 /// Models for Analytics
 pub mod analytics;
+
+/// Models for data set construction
+pub mod datasets;

--- a/sdk/core/src/entities/tasks/task.rs
+++ b/sdk/core/src/entities/tasks/task.rs
@@ -1,4 +1,5 @@
 use crate::entities::analytics::AnalyticProviderKind;
+use crate::entities::datasets::ConstructionProviderKind;
 use crate::entities::enrichments::VulnerabilityProviderKind;
 use crate::entities::sboms::SbomProviderKind;
 use crate::Error;
@@ -98,6 +99,8 @@ pub enum TaskKind {
     Extension(String),
     /// [Task] was performed to execute an Analytic.
     Analytics(AnalyticProviderKind),
+    /// [Task] was performed to construct a data set
+    Construction(ConstructionProviderKind),
 }
 
 impl Display for TaskKind {
@@ -107,6 +110,7 @@ impl Display for TaskKind {
             TaskKind::Sbom(kind) => write!(f, "sbom::{}", kind),
             TaskKind::Extension(name) => write!(f, "extension::{}", name),
             TaskKind::Analytics(kind) => write!(f, "analytic::{}", kind),
+            TaskKind::Construction(kind) => write!(f, "construction::{}", kind),
         }
     }
 }

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::services::purl2cpe::service::Error as Purl2CpeError;
 use thiserror::Error;
 
 /// Represents all exposed Errors for this crate.
@@ -27,9 +28,12 @@ pub enum Error {
     /// Sbom provider error.
     #[error("sbom provider error: {0}")]
     Sbom(String),
+    /// Serialization error
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
     /// Serialization error.
-    #[error("serialization error: {0}")]
-    Serde(String),
+    #[error(transparent)]
+    SerdeYaml(#[from] serde_yaml::Error),
     /// GitHub provider error.
     #[error("github error: {0}")]
     GitHub(String),
@@ -48,6 +52,12 @@ pub enum Error {
     /// Sbom Scorecard processing error
     #[error("Sbom Scorecard processing error: {0}")]
     SbomScorecard(String),
+    /// Error from IO
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Error from platform Git service
+    #[error(transparent)]
+    Purl2Cpe(#[from] Purl2CpeError),
 }
 
 impl From<platform::Error> for Error {

--- a/sdk/core/src/services/analytics/mod.rs
+++ b/sdk/core/src/services/analytics/mod.rs
@@ -56,8 +56,7 @@ impl StorageProvider for FileSystemStorageProvider {
         let target_dir = format!("{}/analytic-{}", self.out_dir, provider_name);
         let file_name = get_file_name(purl)?;
         let file_path = format!("{}/{}", target_dir, file_name);
-        let json_raw = serde_json::to_string(&json)
-            .map_err(|e| Error::Serde(format!("write::to_string::{}", e)))?;
+        let json_raw = serde_json::to_string(&json).map_err(Error::Serde)?;
 
         match std::fs::create_dir_all(target_dir.clone()) {
             Ok(_) => {}
@@ -94,8 +93,7 @@ impl StorageProvider for S3StorageProvider {
         let mut object_key = get_s3_key_name(purl)?;
         object_key = format!("analytic-{}/{}", provider_name, object_key);
 
-        let json_raw = serde_json::to_vec(&json)
-            .map_err(|e| Error::Serde(format!("write::to_string::{}", e)))?;
+        let json_raw = serde_json::to_vec(&json).map_err(Error::Serde)?;
 
         let json_string = json.to_string();
         let cursor = Cursor::new(json_string.into_bytes());

--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -338,6 +338,10 @@ impl AnalyticService {
             }
         };
 
+        if json.as_object().unwrap().is_empty() {
+            return Ok(vec![])
+        }
+
         // Deserialize the Serde Value object into this ad-hoc struct
         #[derive(Deserialize, Debug)]
         struct DeserializedValue {

--- a/sdk/core/src/services/analytics/sboms/service.rs
+++ b/sdk/core/src/services/analytics/sboms/service.rs
@@ -3,6 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
+use crate::entities::datasets::PurlPlusId;
 use crate::services::analytics::StorageProvider;
 use crate::Error;
 use platform::mongo_doc;
@@ -243,13 +244,13 @@ fn report_analytic_stage_11() -> Stage {
 /// Service to create and run analytics on DocumentDB
 pub struct AnalyticService {
     pub(crate) store: Arc<MongoStore>,
-    pub(crate) storage: Arc<dyn StorageProvider>,
+    pub(crate) storage: Option<Arc<dyn StorageProvider>>,
     pub(crate) pipeline: Pipeline,
 }
 
 impl AnalyticService {
     /// Creates a new AnalyticService
-    pub fn new(store: Arc<MongoStore>, storage: Arc<dyn StorageProvider>) -> Self {
+    pub fn new(store: Arc<MongoStore>, storage: Option<Arc<dyn StorageProvider>>) -> Self {
         let pipeline = Pipeline::new(store.clone());
 
         AnalyticService {
@@ -298,6 +299,57 @@ impl AnalyticService {
         }
     }
 
+    /// Method to get dependent packages that have a null cpe.
+    pub async fn get_dependant_package_purls_with_null_cpe(
+        &self,
+    ) -> Result<Vec<PurlPlusId>, Error> {
+        // Analytic is executed on the "Package" collection
+        let collection = "Package";
+
+        // Make sure the pipeline is clear. Is this necessary?
+        self.pipeline.clear();
+
+        // ==> Add the stages
+
+        // Get all of the documents that are dependencies and have a null `cpe` field.
+        // from the "Package" collection.
+        self.pipeline.add_stage(Stage::new(
+            json!({ "$match": { "kind": "dependency", "cpe": null } }),
+        ));
+
+        // Project only the purl field and ignore the rest of the other fields
+        self.pipeline
+            .add_stage(Stage::new(json!({ "$project": { "purl": 1, "id": 1 } })));
+
+        // Group all of the documents into a single document by pushing all of the
+        // purls into an array called "purls"
+        self.pipeline.add_stage(Stage::new(json!({ "$group":
+            { "_id": "", "purls": { "$push": { "id": "$id", "purl": "$purl" } } }
+        })));
+
+        // Execute the Analytic and return the Serde Value object
+        let json = match self.pipeline.execute_on(collection).await {
+            Ok(json) => json,
+            Err(err) => {
+                return Err(Error::Analytic(format!(
+                    "Problem executing analytic: {}",
+                    err
+                )))
+            }
+        };
+
+        // Deserialize the Serde Value object into this ad-hoc struct
+        #[derive(Deserialize, Debug)]
+        struct DeserializedValue {
+            purls: Vec<PurlPlusId>,
+        }
+        let deserialized_value =
+            serde_json::from_value::<DeserializedValue>(json).map_err(Error::Serde)?;
+
+        // Return the Vector of purls
+        Ok(deserialized_value.purls)
+    }
+
     /// Generates a Detail Analytic Report. Specification is here:
     pub(crate) async fn generate_detail(&self, purl: String) -> Result<Option<String>, Error> {
         println!("==> pipeline stages on enter {}", self.pipeline.len());
@@ -342,11 +394,12 @@ impl AnalyticService {
 
         println!("==> pipeline stages after execute {}", self.pipeline.len());
 
-        match self
-            .storage
-            .write(purl.as_str(), json, "detailed-report")
-            .await
-        {
+        let storage = match self.storage.clone() {
+            Some(storage) => storage,
+            None => return Err(Error::Analytic(String::from("No storage provider set"))),
+        };
+
+        match storage.write(purl.as_str(), json, "detailed-report").await {
             Ok(path) => Ok(Some(path)),
             Err(e) => Err(Error::Analytic(format!(
                 "vulnerability::store_by_purl::write::{}",
@@ -400,6 +453,28 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "debug manual only"]
+    async fn test_get_dependant_package_purls_with_null_cpe() {
+        // Mock store and storage provider
+        let cxt: &Context = &test_context(Some("harbor")).expect("Unable to create a test context");
+        let raw_store = MongoStore::new(cxt)
+            .await
+            .expect("Unable to unwrap MongoStore");
+        let store = Arc::new(raw_store);
+        let storage = Arc::new(MockStorageProvider);
+
+        // Create AnalyticService
+        let analytic_service = AnalyticService::new(store, Some(storage));
+
+        let purls: Vec<PurlPlusId> = analytic_service
+            .get_dependant_package_purls_with_null_cpe()
+            .await
+            .expect("Error getting package deps with null cpe");
+
+        println!(">>>>> Purls: {:#?}", purls)
+    }
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
     async fn test_get_primary_purls() {
         // Mock store and storage provider
         let cxt: &Context = &test_context(Some("harbor")).expect("Unable to create a test context");
@@ -410,7 +485,7 @@ mod tests {
         let storage = Arc::new(MockStorageProvider);
 
         // Create AnalyticService
-        let analytic_service = AnalyticService::new(store, storage);
+        let analytic_service = AnalyticService::new(store, Some(storage));
 
         // Execute get_primary_purls
         let result = analytic_service.get_primary_purls().await;
@@ -431,7 +506,7 @@ mod tests {
         let storage = Arc::new(MockStorageProvider);
 
         // Create AnalyticService
-        let analytic_service = AnalyticService::new(store, storage);
+        let analytic_service = AnalyticService::new(store, Some(storage));
 
         // Execute generate_detail
         let result = analytic_service
@@ -453,7 +528,7 @@ mod tests {
             .await
             .expect("Unable to unwrap MongoStore");
         let store = Arc::new(raw_store);
-        let storage = Arc::new(MockStorageProvider);
+        let storage: Option<Arc<dyn StorageProvider>> = Some(Arc::new(MockStorageProvider));
 
         let service = AnalyticService {
             store: store.clone(),

--- a/sdk/core/src/services/mod.rs
+++ b/sdk/core/src/services/mod.rs
@@ -43,3 +43,6 @@ pub mod vendors;
 /// The [products] module contains domain and persistence logic related to the management of
 /// [Product] entities.
 pub mod products;
+
+/// The [purl2cpe] for exposing the service that is responsible for deriving a cpe for a purl
+pub mod purl2cpe;

--- a/sdk/core/src/services/purl2cpe/mod.rs
+++ b/sdk/core/src/services/purl2cpe/mod.rs
@@ -1,0 +1,2 @@
+/// Export the service
+pub mod service;

--- a/sdk/core/src/services/purl2cpe/service.rs
+++ b/sdk/core/src/services/purl2cpe/service.rs
@@ -1,0 +1,486 @@
+use std::ops::Deref;
+use std::path::Path;
+use std::string::FromUtf8Error;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use urlencoding::decode;
+
+use platform::git::Service as Git;
+use platform::persistence::mongodb::service::Service as MongoService;
+use platform::persistence::mongodb::store::Store;
+use platform::Error as PlatformError;
+
+use crate::config::github_pat;
+use crate::entities::datasets::{Cpe, Purl2Cpes};
+use crate::entities::packages::Package;
+
+const PURL_2_CPE_URL: &str = "https://github.com/scanoss/purl2cpe.git";
+const CLONE_PATH: &str = "/tmp/harbor/purl2cpe";
+
+/// Service to build the data set for purl2cpe
+#[derive(Debug)]
+pub struct Purl2CpeService {
+    pub(crate) store: Arc<Store>,
+}
+
+#[async_trait]
+impl MongoService<Purl2Cpes> for Purl2CpeService {
+    /// Getter for the store
+    fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+
+    /// Insert a document into a [Collection].
+    async fn insert<'a>(&self, doc: &mut Purl2Cpes) -> Result<(), PlatformError> {
+        if doc.id.is_empty() {
+            return Err(PlatformError::Mongo(String::from(
+                "==> purl2cpe::id(purl)::empty",
+            )));
+        }
+
+        if doc.cpes.is_empty() {
+            return Err(PlatformError::Mongo(String::from(
+                "==> purl2cpe::cpes::empty",
+            )));
+        }
+
+        self.store.insert(doc).await?;
+        Ok(())
+    }
+}
+
+fn find_cpe(version: String, cpes: Vec<String>) -> Option<String> {
+    let mut final_cpe = None::<String>;
+    let all_versions = String::from("*");
+    let no_version = String::from("-");
+    for cpe_str in cpes {
+        let cpe = Cpe::new(cpe_str);
+
+        // If this conditional evaluates to true, we have exactly
+        // what we want and we can short circuit the loop
+        if cpe.version.eq(&version) {
+            final_cpe = Some(cpe.get_string());
+            break;
+        }
+
+        // If the default is found, we load that up but keep looping
+        if cpe.version.eq(&all_versions) || cpe.version.eq(&no_version) {
+            final_cpe = Some(cpe.get_string());
+        }
+    }
+
+    final_cpe
+}
+
+impl Purl2CpeService {
+    /// Creates a new Purl2CpeService
+    pub fn new(store: Arc<Store>) -> Self {
+        Purl2CpeService { store }
+    }
+
+    /// Method to update a Package document in the store with a cpe
+    pub async fn update_package_with_cpe(&self, id: String, cpe: String) -> Result<(), Error> {
+        let mut package_doc = match self
+            .store
+            .find::<Package>(id.as_str())
+            .await
+            .map_err(Error::Mongo)?
+        {
+            None => {
+                return Err(Error::Purl2Cpe(format!(
+                    "Unable to find Package document in the data store with id: {}",
+                    id
+                )))
+            }
+            Some(package_doc) => package_doc,
+        };
+
+        package_doc.cpe = Some(cpe);
+        self.store
+            .update::<Package>(&package_doc)
+            .await
+            .map_err(Error::Mongo)?;
+
+        Ok(())
+    }
+
+    /// Method to get a cpe for a purl
+    pub async fn get_cpe(&self, full_purl: String) -> Result<Option<String>, Error> {
+        fn error_result(msg: &str) -> Result<Option<String>, Error> {
+            Err(Error::Purl2Cpe(String::from(msg)))
+        }
+
+        let at_sign = '@';
+
+        if full_purl.is_empty() {
+            return error_result("==> unable to process, purl is empty");
+        }
+
+        return if full_purl.contains(at_sign) {
+            let full_purl: Vec<&str> = full_purl.split(at_sign).collect();
+            let purl = full_purl.first();
+            let version = String::from(*full_purl.get(1).unwrap());
+
+            let purl_str = match purl {
+                Some(purl_str) => {
+                    println!(
+                        "==> purl({}) contains version({})",
+                        purl_str,
+                        version.clone()
+                    );
+                    *purl_str
+                }
+                None => {
+                    return error_result("==> unable to get cpe, purl is None while unwrapping")
+                }
+            };
+
+            // If there are percent encoded chars in the purl, like
+            // the at-sign for npm packages, we need to decode the string
+            // so that it matches what is in the Purl2Cpe Collection
+            let decoded_purl_str = decode(purl_str).map_err(Error::PercentEncoding)?;
+
+            match self.store.find::<Purl2Cpes>(decoded_purl_str.deref()).await {
+                // If the database is erroring out, then we can't go on.
+                Err(err) => {
+                    return error_result(
+                        format!("==> unable to get cpe, database error: {}", err).as_str(),
+                    )
+                }
+
+                // The Database gave us a response
+                Ok(option) => match option {
+                    // The response was empty
+                    None => {
+                        println!(
+                            "==> unable to get cpe for purl({}), database response is empty",
+                            purl_str
+                        );
+
+                        Ok(None)
+                    }
+
+                    // The response had CPEs!
+                    Some(purl_2_cpes) => {
+                        let cpes: Vec<String> = purl_2_cpes.cpes;
+
+                        // If there is only one cpe, then return it.
+                        if cpes.len() == 1 {
+                            let cpe = cpes.get(0).unwrap().to_owned();
+                            return Ok(Some(cpe));
+                        }
+
+                        Ok(find_cpe(version, cpes))
+                    }
+                },
+            }
+        } else {
+            // If there are percent encoded chars in the purl, like
+            // the at-sign for npm packages, we need to decode the string
+            // so that it matches what is in the Purl2Cpe Collection
+            let decoded_purl_str = decode(full_purl.as_str()).map_err(Error::PercentEncoding)?;
+
+            match self.store.find::<Purl2Cpes>(decoded_purl_str.deref()).await {
+                // If the database is erroring out, then we can't go on.
+                Err(err) => {
+                    return error_result(
+                        format!("==> unable to get cpe, database error: {}", err).as_str(),
+                    )
+                }
+
+                // The Database gave us a response
+                Ok(option) => match option {
+                    // The response was empty
+                    None => {
+                        println!(
+                            "==> unable to get cpe for purl({}), database response is empty",
+                            full_purl
+                        );
+
+                        Ok(None)
+                    }
+
+                    // the response had CPEs!
+                    Some(purl_2_cpes) => {
+                        let cpes: Vec<String> = purl_2_cpes.cpes;
+
+                        // If there is only one cpe, then return it.
+                        if cpes.len() == 1 {
+                            let cpe = cpes.get(0).unwrap().to_owned();
+                            return Ok(Some(cpe));
+                        }
+
+                        Ok(find_cpe(String::from("*"), cpes))
+                    }
+                },
+            }
+        };
+    }
+
+    /// Clones the purl2cpe repository at:
+    ///     https://github.com/scanoss/purl2cpe
+    pub fn clone_purl2cpe_repo(&self) -> Result<String, Error> {
+        if Path::new(CLONE_PATH).is_dir() {
+            self.remove_purl2cpe_clone()?;
+        }
+
+        let token =
+            github_pat().map_err(|err| Error::Purl2Cpe(format!("Unable to get pat: {}", err)))?;
+        Git::new(String::from(PURL_2_CPE_URL))
+            .clone_repo(CLONE_PATH, Some(token))
+            .map_err(Error::Git)?;
+
+        Ok(String::from(CLONE_PATH))
+    }
+
+    /// Method to find yaml files
+    pub fn find_purl_yaml_files(&self) -> Result<Vec<String>, Error> {
+        let files = Git::new(String::from(PURL_2_CPE_URL))
+            .find(String::from("purls.yml"), String::from(CLONE_PATH))
+            .map_err(Error::Git)?;
+
+        Ok(files)
+    }
+
+    /// Removes a cloned repository from the filesystem.
+    pub fn remove_purl2cpe_clone(&self) -> Result<(), Error> {
+        Git::remove_clone(CLONE_PATH).map_err(Error::Git)
+    }
+}
+
+/// Represents all exposed Errors for this task.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Error to handle percent encoding errors
+    #[error(transparent)]
+    PercentEncoding(#[from] FromUtf8Error),
+    /// Error to map from platform Git Error
+    #[error(transparent)]
+    Git(#[from] platform::git::error::Error),
+    /// Error to map from platform, specifically Mongo
+    #[error(transparent)]
+    Mongo(#[from] platform::Error),
+    /// Error for Perl2Cpe general error
+    #[error("purl2cpe error: {0}")]
+    Purl2Cpe(String),
+}
+
+/*
+ * Why are so many of these tests "debug manual only"?
+ *
+ * The reason is that each of them need specific data loaded into the
+ * database and that should be done by having a set_up() function for
+ * the test suite, but Rust does not support that.  Upon researching,
+ * I found that a custom test framework feature has been developed that
+ * would give us more control over the way the tests are executed and
+ * allow us to solve the problem.  Here is a link from the unstable Rust
+ * Book with the information:
+ *
+ * https://doc.rust-lang.org/unstable-book/language-features/custom-test-frameworks.html#custom_test_frameworks
+ *
+ * Unfortunately, developing a framework for us is too far outside the
+ * scope of the work I'm doing, so I'll just drop a:
+ * TODO Add custom testing framework
+ * Right here and we can talk about it later
+ */
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use platform::persistence::mongodb::Store;
+
+    use crate::config::dev_context;
+    use crate::entities::datasets::Purl2Cpes;
+    use crate::services::purl2cpe::service::{find_cpe, Purl2CpeService};
+
+    async fn add_test_data() {
+        let store = get_store().await;
+        store
+            .drop_collection::<Purl2Cpes>()
+            .await
+            .expect("Unable to drop collection");
+
+        let cpes = vec!["cpe:2.3:a:01org:tpm2.0-tools:1.1.0:*:*:*:*:*:*:*"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let doc = Purl2Cpes::new(String::from("pkg:deb/debian/tpm2-tools"), cpes);
+        store
+            .insert::<Purl2Cpes>(&doc)
+            .await
+            .expect("Data insertion failure");
+
+        let cpes = vec!["cpe:2.3:a:01org:tpm2.0-tools:1.1.0:*:*:*:*:*:*:*"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let doc = Purl2Cpes::new(String::from("pkg:github/tpm2-software/tpm2-tools"), cpes);
+        store
+            .insert::<Purl2Cpes>(&doc)
+            .await
+            .expect("Data insertion failure");
+
+        let cpes = vec![
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.2:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:*:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:-:*:*:*:*:wordpress:*:*",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let doc = Purl2Cpes::new(String::from("pkg:github/wpplugins/0mk-shortener"), cpes);
+        store
+            .insert::<Purl2Cpes>(&doc)
+            .await
+            .expect("Data insertion failure")
+    }
+
+    async fn get_store() -> Arc<Store> {
+        let ctx = dev_context(None).unwrap();
+        let store = Store::new(&ctx).await.unwrap();
+        Arc::new(store)
+    }
+
+    async fn get_test_svc() -> Purl2CpeService {
+        Purl2CpeService::new(get_store().await)
+    }
+
+    #[test]
+    fn test_find_cpe_perfect_match_exists() {
+        let version = String::from("0.9");
+
+        let cpes = vec![
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.2:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:*:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.9:*:*:*:*:wordpress:*:*",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let found_cpe =
+            String::from("cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.9:*:*:*:*:wordpress:*:*");
+        assert_eq!(found_cpe, find_cpe(version, cpes).unwrap());
+    }
+
+    #[test]
+    fn test_find_cpe_no_perfect_match_but_all_versions_exists() {
+        let version = String::from("0.9");
+
+        let cpes = vec![
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.2:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:*:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:1.2:*:*:*:*:wordpress:*:*",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let found_cpe =
+            String::from("cpe:2.3:a:0mk_shortener_project:0mk_shortener:*:*:*:*:*:wordpress:*:*");
+        assert_eq!(found_cpe, find_cpe(version, cpes).unwrap());
+    }
+
+    #[test]
+    fn test_find_cpe_no_perfect_match_but_no_version_exists() {
+        let version = String::from("0.9");
+
+        let cpes = vec![
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.2:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:-:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:1.2:*:*:*:*:wordpress:*:*",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let found_cpe =
+            String::from("cpe:2.3:a:0mk_shortener_project:0mk_shortener:-:*:*:*:*:wordpress:*:*");
+        assert_eq!(found_cpe, find_cpe(version, cpes).unwrap());
+    }
+
+    #[test]
+    fn test_find_cpe_no_perfect_match_or_special_versions_exists() {
+        let version = String::from("0.9");
+
+        let cpes = vec![
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.2:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:3.2:*:*:*:*:wordpress:*:*",
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:1.2:*:*:*:*:wordpress:*:*",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        assert_eq!(None, find_cpe(version, cpes));
+    }
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn test_get_cpe_with_purl_version() {
+        let test_svc = get_test_svc().await;
+        let test_purl = String::from("pkg:deb/debian/tpm2-tools@1.1.0");
+        let cpe: Option<String> = test_svc
+            .get_cpe(test_purl)
+            .await
+            .expect("Should not be Error Result");
+        assert_ne!(None, cpe);
+        assert_eq!(
+            "cpe:2.3:a:01org:tpm2.0-tools:1.1.0:*:*:*:*:*:*:*",
+            cpe.unwrap()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn test_get_cpe_empty_purl() {
+        add_test_data().await;
+        let test_svc = get_test_svc().await;
+        let test_purl = String::from("");
+        let cpe = test_svc.get_cpe(test_purl).await;
+        assert!(cpe.is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn test_get_cpe_with_purl_no_version_single_cpe_entry() {
+        add_test_data().await;
+        let test_svc = get_test_svc().await;
+        let test_no_version_purl = String::from("pkg:github/tpm2-software/tpm2-tools");
+        let cpe = test_svc
+            .get_cpe(test_no_version_purl)
+            .await
+            .expect("Should not be Error Result");
+        assert_ne!(None, cpe);
+        assert_eq!(
+            "cpe:2.3:a:01org:tpm2.0-tools:1.1.0:*:*:*:*:*:*:*",
+            cpe.unwrap()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "debug manual only"]
+    async fn test_get_cpe_with_purl_no_version_multiple_cpe_entry() {
+        add_test_data().await;
+
+        /*
+         * Versions of CPE for "pkg:github/wpplugins/0mk-shortener":
+         * 0. cpe:2.3:a:0mk_shortener_project:0mk_shortener:0.2:*:*:*:*:wordpress:*:*
+         * 1. cpe:2.3:a:0mk_shortener_project:0mk_shortener:*:*:*:*:*:wordpress:*:*
+         * 2. cpe:2.3:a:0mk_shortener_project:0mk_shortener:-:*:*:*:*:wordpress:*:*
+         */
+
+        let test_svc = get_test_svc().await;
+        let test_no_version_purl = String::from("pkg:github/wpplugins/0mk-shortener");
+        let cpe = test_svc
+            .get_cpe(test_no_version_purl)
+            .await
+            .expect("Should not be Error Result");
+        let tco = Some(String::from(
+            "cpe:2.3:a:0mk_shortener_project:0mk_shortener:*:*:*:*:*:wordpress:*:*",
+        ));
+        assert_eq!(tco, cpe);
+    }
+}

--- a/sdk/core/src/services/snyk/adapters.rs
+++ b/sdk/core/src/services/snyk/adapters.rs
@@ -145,7 +145,7 @@ pub(crate) struct Issue {}
 
 impl IssueSnyk {
     pub(crate) fn to_vulnerability(&self, purl: &str) -> Vulnerability {
-        let raw = match serde_json::to_string(&self).map_err(|e| Error::Serde(e.to_string())) {
+        let raw = match serde_json::to_string(&self).map_err(Error::Serde) {
             Ok(raw) => Some(raw),
             Err(_) => None,
         };

--- a/sdk/core/src/services/syft/mod.rs
+++ b/sdk/core/src/services/syft/mod.rs
@@ -116,7 +116,7 @@ fn create_component_name(full_name: String, sub_path_opt: Option<String>) -> Str
 
     if let Some(sub_path) = sub_path_opt {
         if !sub_path.is_empty() {
-            return format!("{}:{}", namespace_and_name, sub_path)
+            return format!("{}:{}", namespace_and_name, sub_path);
         }
     }
 
@@ -140,10 +140,8 @@ fn ensure_purl_in_metadata(
                 Some(component) => {
                     let mut unboxed_component = *component;
 
-                    unboxed_component.name = create_component_name(
-                        full_name.clone(),
-                        sub_path.clone()
-                    );
+                    unboxed_component.name =
+                        create_component_name(full_name.clone(), sub_path.clone());
 
                     if unboxed_component.purl.is_none() {
                         let purl = generate_purl(full_name, version, cataloger, sub_path);
@@ -251,16 +249,10 @@ impl Service {
         };
 
         let output: String = String::from_utf8_lossy(&output.stdout).to_string();
-        let mut sbom: Bom = Bom::parse(output.as_str(), CdxFormat::Json)
-            .map_err(Error::Core)?;
+        let mut sbom: Bom = Bom::parse(output.as_str(), CdxFormat::Json).map_err(Error::Core)?;
 
-        let metadata = ensure_purl_in_metadata(
-            sbom.clone(),
-            full_name,
-            version,
-            cataloger,
-            sub_path
-        );
+        let metadata =
+            ensure_purl_in_metadata(sbom.clone(), full_name, version, cataloger, sub_path);
 
         sbom.metadata = Some(Box::new(metadata));
 
@@ -393,7 +385,7 @@ pub enum Error {
 
     /// Handle errors from core functions
     #[error(transparent)]
-    Core(#[from] CoreError)
+    Core(#[from] CoreError),
 }
 
 /// Module for testing
@@ -409,7 +401,10 @@ mod test {
     use crate::entities::cyclonedx::{Bom, Component, Metadata};
     use crate::entities::sboms::{Author, CdxFormat, Sbom};
     use crate::entities::xrefs::{Xref, XrefKind};
-    use crate::services::syft::{create_component, create_metadata, ensure_purl_in_metadata, generate_purl, Error, Service as Syft, CATALOGERS, create_component_name};
+    use crate::services::syft::{
+        create_component, create_component_name, create_metadata, ensure_purl_in_metadata,
+        generate_purl, Error, Service as Syft, CATALOGERS,
+    };
     use crate::testing::sbom_raw;
 
     fn test_created_component(
@@ -744,17 +739,12 @@ mod test {
 
         let syft = Syft::new(repo_loc.clone());
 
-        let syft_result = syft.execute(
-            full_name,
-            commit_hash,
-            Some(cataloger),
-            None,
-        );
+        let syft_result = syft.execute(full_name, commit_hash, Some(cataloger), None);
 
         Git::remove_clone(repo_loc.as_str()).map_err(|err| Error::Syft(format!("{}", err)))?;
 
-        let sbom = Bom::parse(syft_result.unwrap().as_str(), CdxFormat::Json)
-            .map_err(Error::Core)?;
+        let sbom =
+            Bom::parse(syft_result.unwrap().as_str(), CdxFormat::Json).map_err(Error::Core)?;
 
         let metadata = sbom.metadata.unwrap();
         let component = metadata.component.unwrap();
@@ -800,8 +790,7 @@ mod test {
                         Some(trimmed_pom_path.to_string()),
                     );
 
-                    let sbom = Bom::parse(sbom.as_str(), CdxFormat::Json)
-                        .map_err(Error::Core)?;
+                    let sbom = Bom::parse(sbom.as_str(), CdxFormat::Json).map_err(Error::Core)?;
 
                     let metadata = sbom.metadata.unwrap();
                     let component = metadata.component.unwrap();

--- a/sdk/core/src/services/vulnerabilities/mod.rs
+++ b/sdk/core/src/services/vulnerabilities/mod.rs
@@ -73,8 +73,7 @@ impl StorageProvider for FileSystemStorageProvider {
         let file_name = format!("{}-{}.json", provider, make_file_name_safe(purl)?);
         let file_path = format!("{}/{}", self.out_dir, file_name);
 
-        let json_raw = serde_json::to_string(vulnerabilities)
-            .map_err(|e| Error::Serde(format!("write::to_string::{}", e)))?;
+        let json_raw = serde_json::to_string(vulnerabilities).map_err(Error::Serde)?;
 
         match std::fs::write(file_path.as_str(), json_raw) {
             Ok(_) => {}
@@ -122,8 +121,7 @@ impl StorageProvider for S3StorageProvider {
 
         let object_key = format!("vulnerabilities-{}-{}", provider, to_safe_object_key(purl)?);
 
-        let json_raw = serde_json::to_vec(vulnerabilities)
-            .map_err(|e| Error::Serde(format!("write::to_string::{}", e)))?;
+        let json_raw = serde_json::to_vec(vulnerabilities).map_err(Error::Serde)?;
 
         // TODO: Add checksum to vulnerabilities files and relate Sboms to Vulnerabilities.
         let reader = BufReader::new(json_raw.as_slice());

--- a/sdk/core/src/tasks/construction/dataset/mod.rs
+++ b/sdk/core/src/tasks/construction/dataset/mod.rs
@@ -1,0 +1,2 @@
+/// Expose the purl2cpe build task
+pub mod purl2cpe;

--- a/sdk/core/src/tasks/construction/dataset/purl2cpe.rs
+++ b/sdk/core/src/tasks/construction/dataset/purl2cpe.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::entities::datasets::{CpesContainer, Purl2Cpes, PurlsContainer};
+use platform::persistence::mongodb::{Service, Store};
+
+use crate::entities::tasks::Task;
+use crate::services::purl2cpe::service::Purl2CpeService;
+use crate::tasks::TaskProvider;
+use crate::Error;
+
+use serde_yaml::from_reader;
+
+/// Synchronizes SBOMS for a GitHub Group with Harbor.
+#[derive(Debug)]
+pub struct ConstructionTask {
+    pub(in crate::tasks::construction::dataset) service: Purl2CpeService,
+}
+
+impl ConstructionTask {
+    /// Creates a new AnalyticExecutionTask
+    pub fn new(service: Purl2CpeService) -> Self {
+        Self { service }
+    }
+}
+
+impl Service<Task> for ConstructionTask {
+    fn store(&self) -> Arc<Store> {
+        self.service.store()
+    }
+}
+
+#[async_trait]
+impl TaskProvider for ConstructionTask {
+    async fn run(&self, task: &mut Task) -> Result<HashMap<String, String>, Error> {
+        println!("==> Running ConstructionTask Provider to build purl2cpe dataset");
+
+        // Start by dropping the collection. If we are unable
+        // to do that, then we need to stop now.
+        self.service.store().drop_collection::<Purl2Cpes>().await?;
+
+        println!("==> Purl2Cpes collection dropped, rebuilding...");
+
+        let mut errors = HashMap::<String, String>::new();
+        let orig_dir = env::current_dir().map_err(Error::Io)?;
+        let clone_path = self.service.clone_purl2cpe_repo()?;
+        let file_path = Path::new(&clone_path);
+
+        // Move to the clone's top level directory.  If we can't
+        // do that, then there is something wrong with the filesystem
+        // and we cannot go on.
+        env::set_current_dir(file_path).map_err(Error::Io)?;
+
+        // Find all of the purls.yaml files.
+        let purl_file_names = self
+            .service
+            .find_purl_yaml_files()
+            .map_err(Error::Purl2Cpe)?;
+
+        for purl_file_name in purl_file_names {
+            // The cpes.yaml files are in the same directory as the purls.
+            // So, all we should have to do is change the name
+            let cpe_file_name = purl_file_name.replace("purls", "cpes");
+
+            // Should the purls.yml file somehow not be there, then we need to log the
+            // error and go to the next purls.yml file
+            let purl_yaml = match File::open(purl_file_name.clone()).map_err(Error::Io) {
+                Ok(yaml) => yaml,
+                Err(err) => {
+                    task.err_total += 1;
+                    task.ref_errs(purl_file_name.clone(), err.to_string());
+                    errors.insert(purl_file_name.clone(), err.to_string());
+                    continue;
+                }
+            };
+
+            // Because we just changed the filename, it's more likely this file
+            // might not actually be there.  In that case, we have nothing to do this
+            // iteration and we log the error and go on.
+            let cpe_yaml = match File::open(cpe_file_name.clone()).map_err(Error::Io) {
+                Ok(yaml) => yaml,
+                Err(err) => {
+                    task.err_total += 1;
+                    task.ref_errs(cpe_file_name.clone(), err.to_string());
+                    errors.insert(cpe_file_name.clone(), err.to_string());
+                    continue;
+                }
+            };
+
+            // Deserialize the purls
+            let purls_cont: PurlsContainer =
+                from_reader::<File, PurlsContainer>(purl_yaml).map_err(Error::SerdeYaml)?;
+
+            // Deserialize the cpes
+            let cpes_cont: CpesContainer =
+                from_reader::<File, CpesContainer>(cpe_yaml).map_err(Error::SerdeYaml)?;
+
+            for purl in purls_cont.purls {
+                let mut purl2cpes: Purl2Cpes = Purl2Cpes::new(purl.clone(), cpes_cont.cpes.clone());
+
+                match self.service.insert(&mut purl2cpes).await {
+                    Err(err) => {
+                        task.err_total += 1;
+                        task.ref_errs(purl, err.to_string());
+                        errors.insert(purl2cpes.id.clone(), err.to_string());
+                    }
+                    Ok(()) => {
+                        println!("==> purl inserted: {}", purl);
+                    }
+                }
+            }
+        }
+
+        // Move back to original directory before removing the clone
+        env::set_current_dir(orig_dir).map_err(Error::Io)?;
+        self.service
+            .remove_purl2cpe_clone()
+            .map_err(Error::Purl2Cpe)?;
+
+        Ok(errors)
+    }
+}

--- a/sdk/core/src/tasks/construction/mod.rs
+++ b/sdk/core/src/tasks/construction/mod.rs
@@ -1,0 +1,2 @@
+/// Contains all [TaskProvider] implementations related to data set construction
+pub mod dataset;

--- a/sdk/core/src/tasks/enrichments/identity/cpe/mod.rs
+++ b/sdk/core/src/tasks/enrichments/identity/cpe/mod.rs
@@ -1,0 +1,2 @@
+/// This is the Sync Task where the business logic for updating Cpe(s) from Purl(s) is located
+pub mod sync;

--- a/sdk/core/src/tasks/enrichments/identity/cpe/sync.rs
+++ b/sdk/core/src/tasks/enrichments/identity/cpe/sync.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use platform::persistence::mongodb::{Service, Store};
+
+use crate::entities::datasets::{Purl2Cpes, PurlPlusId};
+use crate::entities::packages::Package;
+use crate::entities::tasks::Task;
+use crate::services::analytics::sboms::service::AnalyticService;
+use crate::services::purl2cpe::service::Purl2CpeService;
+use crate::tasks::TaskProvider;
+use crate::Error;
+
+/// Synchronizes the subset of [Package] entries with the kind of
+/// `dependency` and no `cpe` with a cpe derived from their purl(s).
+#[derive(Debug)]
+pub struct SyncTask {
+    store: Arc<Store>,
+    analytic_service: AnalyticService,
+    purl_2_cpe_service: Purl2CpeService,
+}
+
+#[async_trait]
+impl TaskProvider for SyncTask {
+    async fn run(&self, task: &mut Task) -> Result<HashMap<String, String>, Error> {
+        println!("==> fetching dependency Packages with no cpe");
+        let mut errors = HashMap::new();
+
+        let ids_and_purls_with_null_cpe: Vec<PurlPlusId> = self
+            .analytic_service
+            .get_dependant_package_purls_with_null_cpe()
+            .await?;
+
+        for id_and_purl in ids_and_purls_with_null_cpe.clone() {
+            let id = id_and_purl.id.clone();
+            let purl = id_and_purl.purl.clone();
+
+            println!(
+                "==> Attempting to add cpe to Package with purl: {}, id({})",
+                purl.clone(),
+                id.clone()
+            );
+
+            let cpe_opt = match self.purl_2_cpe_service.get_cpe(purl.to_string()).await {
+                Err(err) => {
+                    println!(
+                        "==> Error getting cpe for: {}, id({}): {}",
+                        purl.clone(),
+                        id.clone(),
+                        err
+                    );
+
+                    task.err_total += 1;
+                    task.ref_errs(id.clone(), format!("no_cpe_for_{}", err));
+                    errors.insert(id.clone(), format!("no_cpe_for_{}", err));
+                    continue;
+                }
+                Ok(cpe_opt) => cpe_opt,
+            };
+
+            let cpe = match cpe_opt {
+                None => {
+                    println!("==> CPE for {}, id({}) is None", purl.clone(), id.clone());
+
+                    task.err_total += 1;
+                    let value = format!("no_cpe_for_{}", purl.clone());
+                    task.ref_errs(id.clone(), format!("no_cpe_for_{}", value.clone()));
+                    errors.insert(id.clone(), format!("no_cpe_for_{}", value.clone()));
+
+                    String::from("unknown")
+                }
+                Some(cpe) => {
+                    println!(
+                        "==> Found CPE({}) for({}), updating Package...",
+                        cpe.clone(),
+                        purl.clone()
+                    );
+                    cpe
+                }
+            };
+
+            match self
+                .purl_2_cpe_service
+                .update_package_with_cpe(id.clone(), cpe.clone())
+                .await
+            {
+                Err(err) => {
+                    println!(
+                        "==> Error attempting to update Package: {}, id({}), with cpe({}): {}",
+                        purl.clone(),
+                        id.clone(),
+                        cpe,
+                        err
+                    );
+
+                    task.err_total += 1;
+                    let value = format!("unable_to_update_document_{}", err);
+                    task.ref_errs(id.clone(), format!("no_cpe_for_{}", value.clone()));
+                    errors.insert(id.clone(), format!("no_cpe_for_{}", value));
+                }
+                Ok(()) => {
+                    println!(
+                        "==> Success! Package({}) with purl({}) updated cpe({})",
+                        id, purl, cpe
+                    );
+                }
+            }
+        }
+
+        Ok(errors)
+    }
+}
+
+impl Service<Package> for SyncTask {
+    fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+}
+
+impl Service<Purl2Cpes> for SyncTask {
+    fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+}
+
+impl Service<Task> for SyncTask {
+    fn store(&self) -> Arc<Store> {
+        self.store.clone()
+    }
+}
+
+impl SyncTask {
+    /// Conventional Constructor.
+    pub fn new(
+        store: Arc<Store>,
+        analytic_service: AnalyticService,
+        purl_2_cpe_service: Purl2CpeService,
+    ) -> SyncTask {
+        SyncTask {
+            store,
+            analytic_service,
+            purl_2_cpe_service,
+        }
+    }
+}

--- a/sdk/core/src/tasks/enrichments/identity/cpe/sync.rs
+++ b/sdk/core/src/tasks/enrichments/identity/cpe/sync.rs
@@ -54,7 +54,7 @@ impl TaskProvider for SyncTask {
         let total = ids_and_purls_with_null_cpe.len();
         println!("==> found {} dependant packages with a null cpe.", total);
         task.count = total as u64;
-        <SyncTask as Service<Task>>::store(&self).update(task).await
+        <SyncTask as Service<Task>>::store(self).update(task).await
             .map_err(|err| Error::Task(err.to_string()))?;
 
         for id_and_purl in ids_and_purls_with_null_cpe.clone() {

--- a/sdk/core/src/tasks/enrichments/identity/mod.rs
+++ b/sdk/core/src/tasks/enrichments/identity/mod.rs
@@ -1,0 +1,3 @@
+/// Contains the [TaskProvider] implementation to update the cpe of dependency kind
+/// [Package]s from their purls.
+pub mod cpe;

--- a/sdk/core/src/tasks/enrichments/mod.rs
+++ b/sdk/core/src/tasks/enrichments/mod.rs
@@ -1,2 +1,5 @@
 /// Contains all [TaskProvider] implementations related to vulnerability data enrichments.
 pub mod vulnerabilities;
+
+/// Contains all [TaskProvider] implementations related to data identity enrichments.
+pub mod identity;

--- a/sdk/core/src/tasks/mod.rs
+++ b/sdk/core/src/tasks/mod.rs
@@ -16,6 +16,9 @@ pub mod enrichments;
 /// Contains all [TaskProvider] implementations related to ingestion tasks.
 pub mod sboms;
 
+/// Contains all [TaskProvider] implementations related to dats set construction.
+pub mod construction;
+
 /// Provides a [Template Method](https://en.wikipedia.org/wiki/Template_method_pattern) for running
 /// and logging Task operations.
 #[async_trait]

--- a/sdk/core/src/tasks/sboms/snyk/sync.rs
+++ b/sdk/core/src/tasks/sboms/snyk/sync.rs
@@ -95,11 +95,7 @@ impl SyncTask {
     }
 
     /// Generates an [Sbom] and associated types from a Snyk [Project].
-    pub(crate) async fn process_target(
-        &self,
-        task: &Task,
-        project: &Project,
-    ) -> Result<(), Error> {
+    pub(crate) async fn process_target(&self, task: &Task, project: &Project) -> Result<(), Error> {
         if project.status == ProjectStatus::Inactive {
             self.handle_inactive(project)?;
             return Ok(());

--- a/sdk/core/tests/common/mod.rs
+++ b/sdk/core/tests/common/mod.rs
@@ -42,9 +42,7 @@ impl Scenario {
                 .map_err(|e| Error::Entity(e.to_string()))
             {
                 Ok(_) => Ok(entity.clone()),
-                Err(e) => {
-                    Err(Error::Entity(e.to_string()))
-                }
+                Err(e) => Err(Error::Entity(e.to_string())),
             }
         })
     }
@@ -64,9 +62,7 @@ impl Scenario {
                 .map_err(|e| Error::Entity(e.to_string()))
             {
                 Ok(_) => Ok(()),
-                Err(e) => {
-                    Err(Error::Entity(e.to_string()))
-                }
+                Err(e) => Err(Error::Entity(e.to_string())),
             }
         })
     }

--- a/sdk/platform/src/git/mod.rs
+++ b/sdk/platform/src/git/mod.rs
@@ -7,6 +7,7 @@ use git2::{Repository, TreeWalkResult};
 use std::path::Path;
 
 /// Git Service
+#[derive(Debug)]
 pub struct Service {
     /// This value is the url of the repository
     repo_url: String,

--- a/sdk/platform/src/persistence/mongodb/analytics.rs
+++ b/sdk/platform/src/persistence/mongodb/analytics.rs
@@ -99,9 +99,11 @@ impl Pipeline {
             None => {
                 self.clear();
 
-                Err(Error::Mongo(String::from(
-                    "No result from DocumentDB Aggregate",
-                )))
+                // Return an Empty value - this is temporary
+                // TODO Refactor this method to return an Option<Value> rather than
+                //  an actual Value.  This way we can know fore sure that there wasn't
+                //  an Error, but an actual empty result.
+                Ok(json!({}))
             }
         }
     }

--- a/sdk/platform/src/persistence/mongodb/store.rs
+++ b/sdk/platform/src/persistence/mongodb/store.rs
@@ -60,6 +60,21 @@ impl Store {
         database.collection::<D>(D::collection().as_str())
     }
 
+    /// Drop collection.  Necessary to re-construct collections
+    /// to build data sets.
+    pub async fn drop_collection<D>(&self) -> Result<(), Error>
+    where
+        D: MongoDocument,
+    {
+        let database = self.database();
+        let collection = database.collection::<D>(D::collection().as_str());
+        collection
+            .drop(None)
+            .await
+            .map_err(|err| Error::Mongo(err.to_string()))?;
+        Ok(())
+    }
+
     /// Find the first item that matches the id and is allowed.
     #[instrument]
     pub async fn find<D>(&self, id: &str) -> Result<Option<D>, Error>


### PR DESCRIPTION
## Summary

This PR will add a purl to cpe enrichment source and a new data set `construction` Provider to create the perl2cpe data set. 

### Added

Adds new Tasks and service that will create a store from data in the https://github.com/scanoss/purl2cpe GitHub repository, then use that data to enrich dependency type Packages with cpe(s) from their purl(s)  

## How to test

1. Set up test environment, specifically, MongoDB must be running
2. Run Snyk ingest provider: `./target/debug/harbor ingest -p snyk --debug`
3. Open Compass, select the `Package` collection and use this filter: `{ kind: "dependency", cpe: null }`. That will show all of the dependencies in MongoDB that have no CPE.
4. Run the purl2cpe dataset building Provider: `./target/debug/harbor construct purl2cpe`.  This builds the purl2cpe data set so we can use it to get CPEs for the purls of the dependencies we just ingested.
5. Using Compass, verify that a `Purl2Cpes` Collection exists in MongoDB and is populated.
6. Lastly, run the purl2cpe _enrichment_ provider: `./target/debug/harbor enrich -p purl2cpe`.  This process will go through the dependencies missing a cpe and add them based on the purl.
7. Once more, open Compass, select the `Package` collection and use this filter: `{ kind: "dependency", cpe: null }`. Now the filter should produce no results
8. Change the filter to: `{ kind: "dependency", cpe: { $ne: "unknown" } }` and verify that results exist.  Look for examples of the "all versions" cpe for a given Package.  I found one by filtering on: `{ purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3" }` for example.  Also, look to make sure the cpe's that have versions line up with the version of the Package. 