### PR TITLE
fix: clean keys before insert

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,9 @@ jobs:
         ports:
           - 27017:27017
     steps:
+      - name: Apt Update
+        run: apt-get update
+        
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.2.0
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,8 +33,8 @@ jobs:
           - 27017:27017
     steps:
       - name: Apt Update
-        run: apt-get update
-        
+        run: sudo apt-get update
+
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.2.0
 

--- a/sdk/core/src/entities/tasks/task.rs
+++ b/sdk/core/src/entities/tasks/task.rs
@@ -71,6 +71,8 @@ impl Task {
 
     /// Add an error string for a specific target.
     pub fn ref_errs(&mut self, target_id: String, err: String) {
+        let target_id = platform::persistence::s3::to_safe_object_key(target_id.as_str())
+            .unwrap_or(format!("invalid-target-id-{}", uuid::Uuid::new_v4()));
         match self.ref_errs.clone() {
             None => {
                 self.ref_errs = Some(HashMap::from([(target_id, err)]));


### PR DESCRIPTION
## Summary

This cleans keys to make them safe for inserting into DocumentDB
Closes #126 

### Added

none

### Changed

none

### Deprecated

none

### Removed

none

### Fixed

ref errors now use sanitized keys

## How to test

Build and run snyk enrichment in dev

