### PR TITLE
add CC0 1.0 license based off of DSACMS standards

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,34 @@
+# License
+
+As a work of the [United States government](https://www.usa.gov/), this project
+is in the public domain within the United States of America.
+
+Additionally, we waive copyright and related rights in the work worldwide
+through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full
+text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the
+public domain by waiving all of their rights to the work worldwide under
+copyright law, including all related and neighboring rights, to the extent
+allowed by law.
+
+You can copy, modify, distribute, and perform the work, even for commercial
+purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor
+are the rights that other persons may have in the work or in how the work is
+used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this
+deed makes no warranties about the work, and disclaims liability for all uses
+of the work, to the fullest extent permitted by applicable law. When using or
+citing the work, you should not imply endorsement by the author or the
+affirmer.


### PR DESCRIPTION
Add CC0 1.0 [license](https://github.com/DSACMS/.github/blob/main/LICENSE.md) based off of DSACMS.


## Summary

Get us on the straight and narrow with respect to having an open license aligning with [Digital Services at CMS defined standards](https://github.com/DSACMS/.github/tree/main).
### Added

N/A

### Changed

N/A

### Deprecated

N/A

### Removed

N/A

### Fixed

N/A

## How to test

N/A
