### PR TITLE
fix: correct copy pasta error in export command handler

### DIFF
--- a/extensions/cms/src/errors.rs
+++ b/extensions/cms/src/errors.rs
@@ -6,6 +6,9 @@ pub enum Error {
     /// Configuration error.
     #[error("config: {0}")]
     Config(String),
+    /// Export provider error.
+    #[error("fisma provider: {0}")]
+    Export(String),
     /// Fisma provider error.
     #[error("fisma provider: {0}")]
     Fisma(String),


### PR DESCRIPTION

## Summary

Export command was invoking the wrong concrete task.

### Fixed

List any bug fixes.

## How to test

- Make sure to clear out the `/tmp/harbor-debug/extensions/export` directory on the local test machine
- Start the devenv
- Run `cargo build`
- Run `./target/debug/harbor-cms export --debug` or alternately `../../target/debug/harbor-cms export --debug` if using direnv
- Confirm console output includes lines like `==> Sbom detail report complete for "pkg:npm/foo.bar@1.1.0"`.
- Check that files are getting generated locally by running `ls /tmp/harbor-debug/extensions/export/analytic-detailed-report | wc -l` and making sure number is greater than 0.
