### PR TITLE
fix: add created to final group stage in export command

### DIFF
--- a/extensions/cms/src/tasks/export.rs
+++ b/extensions/cms/src/tasks/export.rs
@@ -377,6 +377,9 @@ impl ExportService {
                 "fismaId": {
                     "$first": "$fismaId"
                 },
+                "created": {
+                    "$first": "$created"
+                },
                 "report": {
                     "$push": {
                         "name": "$report.name",


### PR DESCRIPTION

## Summary

Added the `created` field to the final group stage run by the `export` command.

### Fixed

Closes #180 

## How to test

- Checkout branch
- `cargo build`
- Start the devenv
- `cargo test --package harbor-cms --lib tasks::export::tests::can_run -- --ignored --exact"
- Check the files in `/tmp/harbor-debug/extensions/export/analytic-detailed-report` and make sure the `created` field is present.
